### PR TITLE
Fediverse compatibility, object resolution, inbox forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ client.connect({ useNewUrlParser: true })
     * [x] Security
       * [x] Signature validation
       * [x] Honor recipient blocklist
-    * [ ] Recursive resolution of related objects
+    * [x] Recursive resolution of related objects
     * [ ] Forwarding from inbox
   * [ ] Shared inbox POST
     * [ ] Delivery to targeted local inboxes
@@ -171,6 +171,7 @@ client.connect({ useNewUrlParser: true })
     * [ ] Rate limits
     * [ ] localhost block
     * [ ] Content sanitization
+    * [x] Recursive object resolution depth limit
   * [ ] Related standards
     * [x] http-signature
     * [x] webfinger
@@ -237,6 +238,7 @@ activityParam | String. Express route parameter used for activity id (defaults t
 collectionParam | String. Express route parameter used for collection id (defaults to `objectParam`)
 context | String, Array. JSON-LD context for your app. Defaults to AcivityStreams + Security vocabs
 store | Replace the default storage model & database backend with your own (see `store/interface.js` for API)
+threadDepth | Controls how far up apex will follow links in incoming activities in order to display the conversation thread & check for inbox forwarding needs  (default 10)
 systemUser | Actor object representing system and used for signing GETs (see below)
 
 Blocked, rejections, and rejected: these routes must be defined in order to track

--- a/README.md
+++ b/README.md
@@ -237,10 +237,33 @@ activityParam | String. Express route parameter used for activity id (defaults t
 collectionParam | String. Express route parameter used for collection id (defaults to `objectParam`)
 context | String, Array. JSON-LD context for your app. Defaults to AcivityStreams + Security vocabs
 store | Replace the default storage model & database backend with your own (see `store/interface.js` for API)
+systemUser | Actor object representing system and used for signing GETs (see below)
 
 Blocked, rejections, and rejected: these routes must be defined in order to track
 these items internally for each actor, but they do not need to be exposed endpoints
 (and probably should not be public even then)
+
+### System User / GET authentication
+
+Some federated apps may require http signature authentication on GET requests.
+To enable this functionality, set the `systemUser` property on your apex instance
+equal to an actor created with `createActor` (generally of type 'Service')
+and saved to your object store.
+Its keys will be used to sign all federated object retrieval requests.
+This property can be set after initializing your apex instance, as
+you will need access to the `createActor` method and a database connection.
+
+```
+const ActivitypubExpress = require('activitypub-express')
+const apex = ActivitypubExpress(options)
+// ... connect to db
+apex.createActor('system-user', 'System user', '', null, 'Service')
+  .then(async actor => {
+    await apex.store.saveObject(actor)
+    apex.systemUser = actor
+  })
+```
+
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ client.connect({ useNewUrlParser: true })
       * [x] Signature validation
       * [x] Honor recipient blocklist
     * [x] Recursive resolution of related objects
-    * [ ] Forwarding from inbox
+    * [x] Forwarding from inbox
+      * [ ] Validation of forwarded messages
   * [ ] Shared inbox POST
     * [ ] Delivery to targeted local inboxes
   * [x] Delivery

--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ module.exports = function (settings) {
   apex.objectParam = settings.objectParam
   apex.activityParam = settings.activityParam || settings.objectParam
   apex.collectionParam = settings.collectionParam || settings.objectParam
+  apex.systemUser = settings.systemUser
   apex.utils = {
     usernameToIRI: apex.idToIRIFactory(apex.domain, settings.routes.actor, apex.actorParam),
     objectIdToIRI: apex.idToIRIFactory(apex.domain, settings.routes.object, apex.objectParam),

--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ module.exports = function (settings) {
   apex.objectParam = settings.objectParam
   apex.activityParam = settings.activityParam || settings.objectParam
   apex.collectionParam = settings.collectionParam || settings.objectParam
+  apex.threadDepth = settings.threadDepth || 10
   apex.systemUser = settings.systemUser
   apex.utils = {
     usernameToIRI: apex.idToIRIFactory(apex.domain, settings.routes.actor, apex.actorParam),

--- a/net/activity.js
+++ b/net/activity.js
@@ -22,6 +22,41 @@ module.exports = {
       next()
     }).catch(next)
   },
+  forwardFromInbox (req, res, next) {
+    const apex = req.app.locals.apex
+    const resLocal = res.locals.apex
+    const activity = req.body
+    if (!(resLocal.activity && resLocal.target)) {
+      return next()
+    }
+    // This is the first time the server has seen this Activity.
+    if (resLocal.isNewActivity !== true) {
+      return next()
+    }
+    // The values of inReplyTo, object, target and/or tag are objects owned by the server
+    if (!(resLocal.linked && resLocal.linked.some(obj => apex.isLocalIRI(obj.id)))) {
+      return next()
+    }
+    // The values of to, cc, and/or audience contain a Collection owned by the server
+    const audience = ['to', 'cc', 'audience']
+      .reduce((acc, prop) => {
+        return activity[prop] ? acc.concat(activity[prop]) : acc
+      }, [])
+      /* Spec says any collection, but really only Followers contains actors
+      * and is used in addressing. Perhaps also Added, depending on what it is
+      * populated with.
+      */
+      .filter(addr => {
+        const isFollow = apex.collectionIRIToActorName(addr, 'followers')
+        const isAdded = apex.collectionIRIToActorName(addr, 'collections')
+        return isFollow || isAdded
+      })
+    if (audience.length) {
+      resLocal.postWork
+        .push(() => apex.addToOutbox(resLocal.target, activity, audience))
+    }
+    next()
+  },
   inboxSideEffects (req, res, next) {
     if (!(res.locals.apex.activity && res.locals.apex.actor)) {
       return next()

--- a/net/activity.js
+++ b/net/activity.js
@@ -221,5 +221,16 @@ module.exports = {
       }
       next()
     }).catch(next)
+  },
+  resolveThread (req, res, next) {
+    const apex = req.app.locals.apex
+    const resLocal = res.locals.apex
+    if (!resLocal.activity) {
+      return next()
+    }
+    apex.resolveReferences(req.body).then(refs => {
+      resLocal.linked = refs
+      next()
+    }).catch(next)
   }
 }

--- a/net/index.js
+++ b/net/index.js
@@ -52,6 +52,7 @@ module.exports = {
       validators.activityObject,
       validators.inboxActivity,
       activity.save,
+      activity.resolveThread,
       activity.inboxSideEffects,
       responders.status
     ],

--- a/net/index.js
+++ b/net/index.js
@@ -54,6 +54,7 @@ module.exports = {
       activity.save,
       activity.resolveThread,
       activity.inboxSideEffects,
+      activity.forwardFromInbox,
       responders.status
     ],
     get: [

--- a/pub/activity.js
+++ b/pub/activity.js
@@ -42,13 +42,16 @@ async function buildTombstone (object) {
   }
 }
 // TODO: track errors during address resolution for redelivery attempts
-async function address (activity, sender) {
-  let audience = []
-  ;['to', 'bto', 'cc', 'bcc', 'audience'].forEach(t => {
-    if (activity[t]) {
-      audience = audience.concat(activity[t])
-    }
-  })
+async function address (activity, sender, audienceOverride) {
+  let audience
+  if (audienceOverride) {
+    audience = audienceOverride
+  } else {
+    audience = ['to', 'bto', 'cc', 'bcc', 'audience']
+      .reduce((acc, t) => {
+        return activity[t] ? acc.concat(activity[t]) : acc
+      }, [])
+  }
   audience = audience.map(t => {
     if (t === 'https://www.w3.org/ns/activitystreams#Public') {
       return null
@@ -87,9 +90,14 @@ async function address (activity, sender) {
   // de-dupe
   return Array.from(new Set(audience))
 }
-
-async function addToOutbox (actor, activity) {
-  const tasks = [this.address(activity, actor), this.toJSONLD(activity)]
+/* audienceOverride: array of IRIs, used in inbox forwarding to
+ * skip normall addressing and deliver to specific audience
+ */
+async function addToOutbox (actor, activity, audienceOverride) {
+  const tasks = [
+    this.address(activity, actor, audienceOverride),
+    this.toJSONLD(activity)
+  ]
   const [addresses, outgoingActivity] = await Promise.all(tasks)
   if (addresses.length) {
     return this.queueForDelivery(actor, outgoingActivity, addresses)

--- a/pub/object.js
+++ b/pub/object.js
@@ -1,6 +1,7 @@
 'use strict'
 module.exports = {
-  resolveObject
+  resolveObject,
+  resolveUnknown
 }
 
 // find object in local DB or fetch from origin server
@@ -17,7 +18,47 @@ async function resolveObject (id, includeMeta) {
     // resolve remote object from id
     object = await this.requestObject(id)
   }
-  // cache
-  await this.store.saveObject(object)
+  // local collections are generated on-demand; not cached
+  if (!this.isLocalCollection(object)) {
+    await this.store.saveObject(object)
+  }
   return object
+}
+
+async function resolveUnknown (objectOrIRI) {
+  let object
+  if (!objectOrIRI) return null
+  // For Link/Mention, we want to resolved the linked object
+  if (objectOrIRI.href) {
+    objectOrIRI = objectOrIRI.href[0]
+  }
+  // check if already cached
+  if (this.isString(objectOrIRI)) {
+    object = await this.store.getActivity(objectOrIRI)
+    if (object) return object
+    object = await this.store.getObject(objectOrIRI)
+    if (object) return object
+    /* As local collections are not represented in the DB, instead being generated
+     * on demand, they up getting requested via http below. Perhaps not the most efficient,
+     * but it avoids creating duplicative logic to resolve implementation-specific IRIs
+     * to collections. Just have to make sure this doesn't get saved back to the object cache
+     */
+    object = await this.requestObject(objectOrIRI)
+  } else {
+    object = objectOrIRI
+  }
+  // cache inline or newly fetched object
+  if (this.validateActivity(object)) {
+    await this.store.saveActivity(object)
+    return object
+  }
+  if (this.validateObject(object)) {
+    // local collections are genreated on-demand; not cached
+    if (!this.isLocalCollection(object)) {
+      await this.store.saveObject(object)
+    }
+    return object
+  }
+  // unable to resolve to a valid object
+  return null
 }

--- a/pub/utils.js
+++ b/pub/utils.js
@@ -10,7 +10,9 @@ module.exports = {
   idToActivityCollectionsFactory,
   idToIRIFactory,
   userAndIdToIRIFactory,
+  isLocalCollection,
   isLocalIRI,
+  isString,
   mergeJSONLD,
   nameToActorStreamsFactory,
   removeMeta,
@@ -139,8 +141,18 @@ function userAndIdToIRIFactory (domain, route, userParam, param) {
   }
 }
 
+function isLocalCollection (object) {
+  if (!object) return false
+  const isCollection = object.type === 'Collection' || object.type === 'OrderedCollection'
+  return isCollection && this.isLocalIRI(object.id)
+}
+
 function isLocalIRI (id) {
   return id.startsWith(`https://${this.domain}`)
+}
+
+function isString (obj) {
+  return (Object.prototype.toString.call(obj) === '[object String]')
 }
 
 const overwriteArrays = {

--- a/spec/functional/inbox.spec.js
+++ b/spec/functional/inbox.spec.js
@@ -107,7 +107,7 @@ describe('inbox', function () {
   })
   beforeEach(function (done) {
     // don't let failed deliveries pollute later tests
-    spyOn(apex.store, 'deliveryRequeue')
+    spyOn(apex.store, 'deliveryRequeue').and.resolveTo(undefined)
     // reset db for each test
     client.db('apexTestingTempDb').dropDatabase()
       .then(() => {
@@ -207,6 +207,34 @@ describe('inbox', function () {
           expect(inbox.orderedItems.length).toBe(0)
           done()
         })
+    })
+    it('forwards from inbox', async function (done) {
+      const mockedUser = 'https://mocked.com/u/mocked'
+      spyOn(apex, 'getFollowers').and
+        .resolveTo({ orderedItems: [mockedUser] })
+      await apex.store.saveActivity(activityNormalized)
+      const reply = await apex.buildActivity(
+        'Create',
+        'https://ignore.com/bob',
+        [testUser.id, testUser.followers[0]],
+        { object: { id: 'https://ignore.com/o/abc123', type: 'Note', inReplyTo: activityNormalized.id } }
+      )
+      reply.id = 'https://ignore.com/s/123abc'
+      nock('https://mocked.com')
+        .get('/u/mocked')
+        .reply(200, { id: mockedUser, inbox: 'https://mocked.com/inbox/mocked' })
+      nock('https://mocked.com').post('/inbox/mocked')
+        .reply(200)
+        .on('request', (req, interceptor, body) => {
+          expect(JSON.parse(body).id).toBe('https://ignore.com/s/123abc')
+          done()
+        })
+      request(app)
+        .post('/inbox/test')
+        .set('Content-Type', 'application/activity+json')
+        .send(await apex.toJSONLD(reply))
+        .expect(200)
+        .end(err => { if (err) done(err) })
     })
     // activity sideEffects
     it('fires create event', function (done) {

--- a/spec/functional/outbox.spec.js
+++ b/spec/functional/outbox.spec.js
@@ -97,7 +97,7 @@ describe('outbox', function () {
   })
   beforeEach(function (done) {
     // don't let failed deliveries pollute later tests
-    spyOn(apex.store, 'deliveryRequeue')
+    spyOn(apex.store, 'deliveryRequeue').and.resolveTo(undefined)
 
     // reset db for each test
     client.db('apexTestingTempDb').dropDatabase()

--- a/spec/functional/outbox.spec.js
+++ b/spec/functional/outbox.spec.js
@@ -217,6 +217,8 @@ describe('outbox', function () {
           // valid signature
           req.originalUrl = req.path
           const sigHead = httpSignature.parse(req)
+          // mastodon 3.2.1 requirement
+          expect(sigHead.params.headers).toContain('digest')
           expect(httpSignature.verifySignature(sigHead, testUser.publicKey[0].publicKeyPem[0])).toBeTruthy()
           done()
         })


### PR DESCRIPTION
Combined a few items in this PR that would otherwise have generated merge conflicts:

authentication requirements for compatibility with mastodon >=3.2.1
* add & sign digest header on POST
* optionally sign GETs

Pleroma compatibility
* remove unnecessary Accept header on POSTs

fixes #5 

Recursive object resolution
* follows links in incoming activities to ensure the full conversation thread is available

Forwarding from inbox
* https://www.w3.org/TR/activitypub/#inbox-forwarding
* Helps ensure complete threads are available on different servers