### PR TITLE
More bugfixes & usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ logger | Object with `info`, `warn`, `error` methods to replace `console`
 store | Replace the default storage model & database backend with your own (see `store/interface.js` for API)
 threadDepth | Controls how far up apex will follow links in incoming activities in order to display the conversation thread & check for inbox forwarding needs  (default 10)
 systemUser | Actor object representing system and used for signing GETs (see below)
+offlineMode | Disable delivery. Useful for running migrations and queueing deliveries to be sent when app is running
 
 Blocked, rejections, and rejected: these routes must be defined in order to track
 these items internally for each actor, but they do not need to be exposed endpoints

--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ module.exports = function (settings) {
   apex.threadDepth = settings.threadDepth || 10
   apex.systemUser = settings.systemUser
   apex.logger = settings.logger || console
+  apex.offlineMode = settings.offlineMode
   apex.utils = {
     usernameToIRI: apex.idToIRIFactory(apex.domain, settings.routes.actor, apex.actorParam),
     objectIdToIRI: apex.idToIRIFactory(apex.domain, settings.routes.object, apex.objectParam),

--- a/net/validators.js
+++ b/net/validators.js
@@ -214,7 +214,7 @@ function targetActorWithMeta (req, res, next) {
     // for temp in-memory storage
     actorObj._local = {}
     resLocal.target = actorObj
-    return apex.getBlocked(actorObj, Infinity)
+    return apex.getBlocked(actorObj, Infinity, true)
   }).then(blocked => {
     if (blocked) {
       resLocal.target._local.blockList = blocked.orderedItems

--- a/pub/activity.js
+++ b/pub/activity.js
@@ -42,6 +42,11 @@ async function buildTombstone (object) {
 }
 // TODO: track errors during address resolution for redelivery attempts
 async function address (activity, sender, audienceOverride) {
+  // ensure blocklist is available (e.g. if called outside of route)
+  if (!sender._local?.blockList) {
+    sender._local = sender._local ?? {}
+    sender._local.blockList = (await this.getBlocked(sender, Infinity, true)).orderedItems
+  }
   let audience
   if (audienceOverride) {
     audience = audienceOverride

--- a/pub/activity.js
+++ b/pub/activity.js
@@ -66,7 +66,7 @@ async function address (activity, sender, audienceOverride) {
       if (!sender.preferredUsername.includes(miscCol.actor)) {
         return null
       }
-      return this.getAdded(t, Infinity).then(col => {
+      return this.getAdded(t, Infinity, true).then(col => {
         col.orderedItems = col.orderedItems.reduce((actors, activity) => {
           return actors.concat(
             activity.actor,

--- a/pub/federation.js
+++ b/pub/federation.js
@@ -92,7 +92,9 @@ async function queueForDelivery (actor, activity, addresses) {
 }
 
 function startDelivery () {
-  if (isDelivering) return
+  if (isDelivering || this.offlineMode) {
+    return
+  }
   return this.runDelivery()
 }
 

--- a/spec/functional/inbox.spec.js
+++ b/spec/functional/inbox.spec.js
@@ -221,6 +221,7 @@ describe('inbox', function () {
       const block = merge({}, activityNormalized)
       block.type = 'Block'
       block.object = ['https://ignore.com/u/chud']
+      delete block.audience // not public
       block._meta = { collection: [apex.utils.nameToBlockedIRI(testUser.preferredUsername)] }
       await apex.store.saveActivity(block)
       const act = merge({}, activity)
@@ -232,7 +233,7 @@ describe('inbox', function () {
         .expect(200)
         .end(async (err) => {
           if (err) return done(err)
-          const inbox = await apex.getInbox(testUser, Infinity)
+          const inbox = await apex.getInbox(testUser, Infinity, true)
           expect(inbox.orderedItems.length).toBe(0)
           done()
         })

--- a/spec/unit/federation.spec.js
+++ b/spec/unit/federation.spec.js
@@ -111,11 +111,18 @@ describe('federation', function () {
       body = await apex.toJSONLD(act)
       bodyString = apex.stringifyPublicJSONLD(body)
       addresses = ['https://mocked.com/bob/inbox', 'https://ignore.com/sally/inbox']
+      apex.offlineMode = false
     })
     it('starts delivery process after queueing', async function () {
       spyOn(apex, 'runDelivery')
       await apex.queueForDelivery(testUser, body, addresses)
       expect(apex.runDelivery).toHaveBeenCalled()
+    })
+    it('does not start delivery in offline mode', async function () {
+      spyOn(apex, 'runDelivery')
+      apex.offlineMode = true
+      await apex.queueForDelivery(testUser, body, addresses)
+      expect(apex.runDelivery).not.toHaveBeenCalled()
     })
     it('continues delivering until queue is empty', async function (done) {
       spyOn(apex, 'deliver').and.resolveTo({ statusCode: 200 })


### PR DESCRIPTION
* Fix internal collection use failing to specify authorized flag
* `offlineMode` setting to disable federated delivery, allowing migrations to populate deliveryQueue with items to be sent when server is back online
* Fill in missing actor local blocklist copy in `address` so that it (and utils that call it) can be called directly