### PR TITLE
Include resolve actors in streams

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,49 @@
+2.0.0
+
+Improved client-to-server usability
+
+**Breaking changes**
+* The form of some collection items have been updated to provide resolved objects instead of IDs
+  * inbox, outbox, shares, likes, added: activity with embedded actor object
+  * followers: followed actor as object
+  * liked: liked activity as object (actor not embedded)
+  * following, blocked, rejected, rejections: continue to return ID string
+
+
+1.0.2
+
+Bugfixes and usability improvements
+
+Improvements:
+* `offlineMode` setting to disable federated delivery, allowing migrations to populate deliveryQueue with items to be sent when server is back online
+
+Bugfixes:
+
+* Fix internal collection use failing to specify authorized flag
+* Fill in missing actor local blocklist copy in `address` so that it (and utils that call it) can be called directly
+
+
+1.0.1
+
+Bugfixes and usability improvements
+
+- require authorization on outbox post
+- fix bug with validating actor.streams collection ownership
+- fix outbox post response wrong code (200 -> 201) and missing location header
+- make context truly optional and also in-addition-to rather than replace the defaults
+- publishing utility clarification:
+  - addToOutbox now does all steps to add a newly created activity to outbox (for implementations to publish auto-generated activities)
+  - split off specific addressing, preparing, queueing work into publishActivity (more for internal use)
+- fix generated activities not appearing outbox, resume adding blocks to outbox collection (still does not deliver) now that we have permission-based filtering to control display of blocks
+- remove follow and block from denormalize list - dont really need a bunch of copies of my own actor object in my inbox follows
+- test & fix addressing to followers not pulling non-public followers
+- do not add meta in `buildActivity` so that it can be used by implementations to prepare outbox activities
+
+
+1.0.0
+
+First major release includes all "must" and "should" directives from the ActivityPub spec.
+
 0.1.0
 
 * **Breaking change** Side-effect events refactored. There are now only 2 events,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activitypub-express",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Modular ActivityPub implementation as Express middleware to easily add decentralization and federation to Node apps",
   "main": "index.js",
   "engines": {

--- a/spec/functional/combined.spec.js
+++ b/spec/functional/combined.spec.js
@@ -42,7 +42,7 @@ describe('combined inbox/outbox flows', function () {
     delete follow._meta
     nock('https://mocked.com')
       .get('/u/mocked')
-      .reply(200, { id: 'https://mocked.com/u/mocked', inbox: 'https://mocked.com/u/mocked/inbox' })
+      .reply(200, { id: 'https://mocked.com/u/mocked', type: 'Actor', inbox: 'https://mocked.com/u/mocked/inbox' })
     // accept & update delivery
     nock('https://mocked.com')
       .post('/u/mocked/inbox')
@@ -82,7 +82,7 @@ describe('combined inbox/outbox flows', function () {
       .send(accept)
       .expect(201)
     expect((await apex.getFollowers(testUser, Infinity, true)).orderedItems)
-      .toEqual(['https://mocked.com/u/mocked'])
+      .toEqual([{ id: 'https://mocked.com/u/mocked', type: 'Actor', inbox: ['https://mocked.com/u/mocked/inbox'] }])
     const note = {
       type: 'Note',
       content: 'Hello world',

--- a/spec/helpers/test-utils.js
+++ b/spec/helpers/test-utils.js
@@ -66,3 +66,11 @@ function skipTransient (key, value) {
   }
   return value
 }
+
+global.toExternalJSONLD = async function (apex, value, noContext) {
+  value = JSON.parse(apex.stringifyPublicJSONLD(await apex.toJSONLD(value)))
+  if (noContext) {
+    delete value['@context']
+  }
+  return value
+}

--- a/store/index.js
+++ b/store/index.js
@@ -145,11 +145,14 @@ class ApexStore extends IApexStore {
       .replaceOne({ documentUrl }, context, { forceServerObjectId: true, upsert: true })
   }
 
-  getStream (collectionId, limit, after) {
+  getStream (collectionId, limit, after, blockList) {
     const pipeline = []
     const filter = { '_meta.collection': collectionId }
     if (after) {
       filter._id = { $lt: new mongo.ObjectId(after) }
+    }
+    if (blockList?.length) {
+      filter.actor = { $nin: blockList }
     }
     pipeline.push({ $match: filter })
     pipeline.push({ $sort: { _id: -1 } })
@@ -163,6 +166,9 @@ class ApexStore extends IApexStore {
         foreignField: 'id',
         as: 'actor'
       }
+    }, {
+      // filter if missing actor
+      $match: { actor: { $ne: [] } }
     }, {
       $project: {
         _meta: 0,

--- a/store/index.js
+++ b/store/index.js
@@ -146,18 +146,34 @@ class ApexStore extends IApexStore {
   }
 
   getStream (collectionId, limit, after) {
+    const pipeline = []
     const filter = { '_meta.collection': collectionId }
     if (after) {
       filter._id = { $lt: new mongo.ObjectId(after) }
     }
-    const query = this.db
-      .collection('streams')
-      .find(filter)
-      .sort({ _id: -1 })
-      .project({ _meta: 0, 'object._id': 0, 'object._meta': 0 })
+    pipeline.push({ $match: filter })
+    pipeline.push({ $sort: { _id: -1 } })
     if (limit) {
-      query.limit(limit)
+      pipeline.push({ $limit: limit })
     }
+    pipeline.push({
+      $lookup: {
+        from: 'objects',
+        localField: 'actor',
+        foreignField: 'id',
+        as: 'actor'
+      }
+    }, {
+      $project: {
+        _meta: 0,
+        'object._id': 0,
+        'object._meta': 0,
+        'actor._meta': 0,
+        'actor._id': 0
+      }
+    })
+
+    const query = this.db.collection('streams').aggregate(pipeline)
     return query.toArray().then(stream => unescape(stream))
   }
 


### PR DESCRIPTION
Make it easier to work with inbox streams on the client side by embedded the full actor object for each activitiy

* [x] aggregation pipeline to join actor object in getStream / inbox
* [x] Evaluate how this affects other collections, update tests & docs