### PR TITLE
client-to-server Unfollow

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,12 @@ Override this by setting `response.locals.apex.authorizedUserId` to an actor IRI
 if the `authorizedUserId` is the item's owner.
 Override this by setting `response.locals.apex.authorized` to `true` (allow) or `false` (deny)
 
+* Client-to-server unfollow: to remove an actor from followers, an "Undo" must be sent with
+the object being the prior outgoing "Follow" and likewise to remove from following a "Reject"
+must be sent with object being the prior incoming "Follow." As these past activity ids are
+not readily available to clients, the client may send the undo or reject with an Actor id as
+the object, and the server will find the related Follow and substitute it before publishing.
+
 ### Federation notes
 
 * **http signaures**

--- a/net/validators.js
+++ b/net/validators.js
@@ -297,8 +297,27 @@ function outboxActivityObject (req, res, next) {
     object = activity.object[0]
     object.id = apex.utils.objectIdToIRI()
   }
-  Promise.resolve(object).then(obj => {
+  Promise.resolve(object).then(async obj => {
     resLocal.object = obj
+    // for unfollow, clients dont have easy access to old follow activitiy ids,
+    // so they can send an actor id and server will find related follow
+    if (!obj && type === 'undo') {
+      const actorId = apex.objectIdFromActivity(activity)
+      const follow = await apex.store
+        .findActivityByCollectionAndObjectId(resLocal.target.following[0], actorId, true)
+      if (follow) {
+        activity.object = [follow]
+        resLocal.object = follow
+      }
+    } else if (!obj && type === 'reject') {
+      const actorId = apex.objectIdFromActivity(activity)
+      const follow = await apex.store
+        .findActivityByCollectionAndActorId(resLocal.target.followers[0], actorId, true)
+      if (follow) {
+        activity.object = [follow]
+        resLocal.object = follow
+      }
+    }
     next()
   }).catch(err => {
     apex.logger.warn('Error resolving outbox activity object', err.message)

--- a/pub/activity.js
+++ b/pub/activity.js
@@ -229,7 +229,9 @@ async function resolveActivity (id, includeMeta) {
     // resolve remote activity object
     activity = await this.requestObject(id)
   }
-  // cache
-  await this.store.saveActivity(activity)
-  return activity
+  // cache & return if valid
+  if (this.validateActivity(activity)) {
+    await this.store.saveActivity(activity)
+    return activity
+  }
 }

--- a/pub/activity.js
+++ b/pub/activity.js
@@ -229,7 +229,8 @@ async function resolveActivity (id, includeMeta) {
     // resolve remote activity object
     activity = await this.requestObject(id)
   }
-  // cache & return if valid
+  // avoid saving non-acticity objects to streams collection
+  // if they are encountered during activity validation
   if (this.validateActivity(activity)) {
     await this.store.saveActivity(activity)
     return activity

--- a/store/index.js
+++ b/store/index.js
@@ -134,6 +134,24 @@ class ApexStore extends IApexStore {
       .then(act => unescape(act))
   }
 
+  findActivityByCollectionAndObjectId (collection, objectId, includeMeta) {
+    return this.db.collection('streams')
+      .find({ '_meta.collection': collection, object: objectId })
+      .limit(1)
+      .project(includeMeta ? this.metaProj : this.projection)
+      .next()
+      .then(act => unescape(act))
+  }
+
+  findActivityByCollectionAndActorId (collection, actorId, includeMeta) {
+    return this.db.collection('streams')
+      .find({ '_meta.collection': collection, actor: actorId })
+      .limit(1)
+      .project(includeMeta ? this.metaProj : this.projection)
+      .next()
+      .then(act => unescape(act))
+  }
+
   getContext (documentUrl) {
     return this.db.collection('contexts')
       .findOne({ documentUrl }, { projection: { _id: 0 } })

--- a/store/interface.js
+++ b/store/interface.js
@@ -15,7 +15,15 @@ module.exports = class IApexStore {
     throw new Error('Not implemented')
   }
 
-  getActivity (id) {
+  getActivity (id, includeMeta) {
+    throw new Error('Not implemented')
+  }
+
+  findActivityByCollectionAndObjectId (collection, objectId, includeMeta) {
+    throw new Error('Not implemented')
+  }
+
+  findActivityByCollectionAndActorId (collection, actorId, includeMeta) {
     throw new Error('Not implemented')
   }
 


### PR DESCRIPTION
Unfollow was difficult to achieve because you need a reference to a past follow activity, this change allows the client to send a actor id instead and the server finds the necessary Follow activity and inserts it into the outgoing Undo/Reject