### PR TITLE
request-compose as a replacement for deprecated request lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1544,6 +1544,14 @@
         "sshpk": "^1.7.0"
       }
     },
+    "http-signature-header": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-signature-header/-/http-signature-header-2.0.1.tgz",
+      "integrity": "sha512-m3l3Uv417YpR1iVo6ojLxTpeaiCDOPl4P/tVbZv85wnWvVgtw41ao7zDY1lLTU+mnQSGUajZfBkYmYTME5roPA==",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -1866,7 +1874,8 @@
     "lodash": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -2642,23 +2651,10 @@
         "uuid": "^3.3.2"
       }
     },
-    "request-promise-core": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
-      "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
-      "requires": {
-        "lodash": "^4.17.15"
-      }
-    },
-    "request-promise-native": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
-      "integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
-      "requires": {
-        "request-promise-core": "1.1.3",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      }
+    "request-compose": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/request-compose/-/request-compose-2.1.3.tgz",
+      "integrity": "sha512-7fGL3Hhv5ML0J0+643Rvqe2I+icNNeizw6SZ3lboXziKQ75I1iZs9+72jNmf6k3Vpp0d45MzzDtYXRHH+9YOxg=="
     },
     "require_optional": {
       "version": "1.0.1",
@@ -2928,11 +2924,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
-    },
-    "stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "string-width": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
     "deepmerge": "^4.2.2",
     "express": "^4.17.1",
     "http-signature": "github:wmurphyrd/node-http-signature#9c02eeb",
+    "http-signature-header": "^2.0.1",
     "jsonld": "^3.2.0",
     "mongo-escape": "^2.0.6",
     "mongodb": "^3.6.3",
     "on-finished": "^2.3.0",
     "overlaps": "^1.0.0",
-    "request": "^2.88.0",
-    "request-promise-native": "^1.0.7"
+    "request-compose": "^2.1.3"
   },
   "devDependencies": {
     "jasmine": "^3.5.0",

--- a/pub/federation.js
+++ b/pub/federation.js
@@ -1,6 +1,5 @@
 'use strict'
-const request = require('request-promise-native')
-const crypto = require('crypto')
+const request = require('./request')
 
 // federation communication utilities
 module.exports = {
@@ -15,24 +14,28 @@ module.exports = {
 let isDelivering = false
 let nextDelivery = null
 
-function requestObject (id) {
+async function requestObject (id) {
   if (this.isProductionEnv() && this.isLocalhostIRI(id)) {
     return null
   }
   const req = {
     url: id,
+    method: 'GET',
     headers: { Accept: 'application/activity+json' },
-    json: true
   }
   if (this.systemUser) {
     req.httpSignature = {
       key: this.systemUser._meta.privateKey,
       keyId: this.systemUser.id,
-      headers: ['(request-target)', 'host', 'date'],
-      authorizationHeaderName: 'Signature'
+      // headers: ['(request-target)', 'host', 'date'],
+      // authorizationHeaderName: 'Signature'
     }
   }
-  return request(req).then(this.fromJSONLD)
+  return request(req)
+          .then(({body}) => this.fromJSONLD(body))
+          .catch((error) => {
+            console.error(error)
+          })
 }
 
 const refProps = ['inReplyTo', 'object', 'target', 'tag']
@@ -59,25 +62,20 @@ function deliver (actorId, activity, address, signingKey) {
   if (this.isProductionEnv() && this.isLocalhostIRI(address)) {
     return null
   }
-  // digest header added for Mastodon 3.2.1 compatibility
-  const digest = crypto.createHash('sha256')
-    .update(activity)
-    .digest('base64')
+
   return request({
     method: 'POST',
     url: address,
     headers: {
       'Content-Type': this.consts.jsonldOutgoingType,
-      Digest: `SHA-256=${digest}`
     },
+    mastodonCompatible: true,
     httpSignature: {
       key: signingKey,
       keyId: actorId,
-      headers: ['(request-target)', 'host', 'date', 'digest'],
-      authorizationHeaderName: 'Signature'
+      // includeHeaders: ['(request-target)', 'host', 'date', 'digest'],
+      // authorizationHeaderName: 'Signature'
     },
-    resolveWithFullResponse: true,
-    simple: false,
     body: activity
   })
 }
@@ -118,10 +116,11 @@ async function runDelivery () {
   try {
     const { actorId, body, address, signingKey } = toDeliver
     const result = await this.deliver(actorId, body, address, signingKey)
-    this.logger.info('delivery:', address, result.statusCode)
-    if (result.statusCode >= 500) {
+    const statusCode = result.statusCode || result.res.statusCode
+    this.logger.info('delivery:', address, statusCode)
+    if (statusCode >= 500) {
       // 5xx errors will get requeued
-      throw new Error(`Request status ${result.statusCode}`)
+      throw new Error(`Request status ${statusCode}`)
     }
   } catch (err) {
     this.logger.warn(`Delivery error ${err.message}, requeuing`)

--- a/pub/request.js
+++ b/pub/request.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const crypto = require('crypto')
+const {createAuthzHeader, createSignatureString} = require('http-signature-header');
+
+const compose = require('request-compose');
+const Request = compose.Request
+const Response = compose.Response
+
+// Request with http-signature-header signing
+const request = async (spec) => compose(
+    Request.defaults(),
+    Request.url(spec.url),
+    split(spec),
+    addDigest(),
+    addHttpSignature(),
+    Request.send(),
+    Response.buffer(),
+    Response.string(),
+    Response.parse(),
+    // ({res, body}) => Object.assign({}, res, body),
+)(spec)
+
+const split = (spec) => ({options}) => new Promise((resolve, reject) => {
+  const { body } = spec
+  Object.assign(options, spec)
+  resolve({options, body})
+})
+
+const addDigest = () => ({options, body}) => new Promise((resolve, reject) => {
+  if (!options.mastodonCompatible) resolve({options, body})
+  const digest = crypto.createHash('sha256')
+    .update(body)
+    .digest('base64')
+
+  options.headers = options.headers || {}
+  options.headers['Digest'] = `SHA-256=${digest}`
+
+  if (!options.httpSignature.includeHeaders || !options.httpSignature.includeHeaders.includes('digest')) {
+    options.appendIncludeHeaders = options.appendIncludeHeaders || []
+    options.appendIncludeHeaders.push('digest')
+  }
+  resolve({options, body})
+})
+
+const addHttpSignature = () => ({options, body}) => new Promise((resolve, reject) => {
+  if (!options.httpSignature) resolve({options, body})
+  if (!options.httpSignature.key || !options.httpSignature.keyId) 
+    reject(new Error('missing httpSignature key or keyId'))
+
+  const authorizationHeaderName = options.httpSignature.authorizationHeaderName || 'Signature'
+  const algorithm = options.httpSignature.algorithm || 'rsa-sha256'
+  const defaultIncludeHeaders = options.httpSignature.includeHeaders || ['(request-target)', 'host', 'date']
+  const includeHeaders = defaultIncludeHeaders.concat(options.appendIncludeHeaders || [])
+  if (includeHeaders.includes('date') && !options.headers.date) {
+    options.headers.date = new Date().toUTCString()
+  }
+  options.httpSignature.includeHeaders = includeHeaders
+  const stringToSign = createSignatureString({includeHeaders, requestOptions: options})
+
+  let signer
+  switch (algorithm) {
+    case 'rsa-sha256':
+      signer = crypto.createSign('sha256');
+      break;
+    default:
+      signer = crypto.createSign('sha256');
+      break;
+  }
+  signer.update(stringToSign);
+  const signatureHash = signer.sign(options.httpSignature.key).toString('base64');
+
+  let authz = createAuthzHeader({
+    algorithm: algorithm,
+    includeHeaders: includeHeaders,
+    keyId: options.httpSignature.keyId,
+    signature: signatureHash
+  });
+  if (authorizationHeaderName.toLowerCase() === 'Signature'.toLowerCase()) {
+    authz = authz.substr('Signature '.length)
+  }
+  options.headers[authorizationHeaderName] = authz
+
+  resolve({options, body})
+})
+
+/* Example Use
+const reqSpec = {
+  method: 'POST',
+  url: 'https://example.org/test',
+  headers: {
+    'Content-Type': 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+  },
+  mastodonCompatible: true,
+  httpSignature: {
+    key: '-----BEGIN RSA PRIVATE KEY-----MIIEpAIB...',
+    keyId: 'key-1',
+  },
+  body: 'some body here'
+}
+const result = await request(reqSpec)
+*/
+module.exports = request;

--- a/spec/unit/request.spec.js
+++ b/spec/unit/request.spec.js
@@ -1,0 +1,194 @@
+/* global describe, beforeAll, beforeEach, it, expect */
+
+const httpSignature = require('http-signature')
+const {parseRequest} = require('http-signature-header');
+const http = require('http')
+const request = require('../../pub/request')
+
+const privateKeyPEMs = {}
+
+privateKeyPEMs['key-1'] =
+  '-----BEGIN RSA PRIVATE KEY-----\n' +
+  'MIIEpAIBAAKCAQEAzWSJl+Z9Bqv00FVL5N3+JCUoqmQPjIlya1BbeqQroNQ5yG1i\n' +
+  'VbYTTnMRa1zQtR6r2fNvWeg94DvxivxIG9diDMnrzijAnYlTLOl84CK2vOxkj5b6\n' +
+  '8zrLH9b/Gd6NOHsywo8IjvXvCeTfca5WUHcuVi2lT9VjygFs1ILG4RyeX1BXUumu\n' +
+  'Y8fzmposxLYdMxCqUTzAn0u9Saq2H2OVj5u114wS7OQPigu6G99dpn/iPHa3zBm8\n' +
+  '7baBWDbqZWRW0BP3K6eqq8sut1+NLhNW8ADPTdnO/SO+kvXy7fqd8atSn+HlQcx6\n' +
+  'tW42dhXf3E9uE7K78eZtW0KvfyNGAjsI1Fft2QIDAQABAoIBAG1exe3/LEBrPLfb\n' +
+  'U8iRdY0lxFvHYIhDgIwohC3wUdMYb5SMurpNdEZn+7Sh/fkUVgp/GKJViu1mvh52\n' +
+  'bKd2r52DwG9NQBQjVgkqY/auRYSglIPpr8PpYNSZlcneunCDGeqEY9hMmXc5Ssqs\n' +
+  'PQYoEKKPN+IlDTg6PguDgAfLR4IUvt9KXVvmB/SSgV9tSeTy35LECt1Lq3ozbUgu\n' +
+  '30HZI3U6/7H+X22Pxxf8vzBtzkg5rRCLgv+OeNPo16xMnqbutt4TeqEkxRv5rtOo\n' +
+  '/A1i9khBeki0OJAFJsE82qnaSZodaRsxic59VnN8sWBwEKAt87tEu5A3K3j4XSDU\n' +
+  '/avZxAECgYEA+pS3DvpiQLtHlaO3nAH6MxHRrREOARXWRDe5nUQuUNpS1xq9wte6\n' +
+  'DkFtba0UCvDLic08xvReTCbo9kH0y6zEy3zMpZuJlKbcWCkZf4S5miYPI0RTZtF8\n' +
+  'yps6hWqzYFSiO9hMYws9k4OJLxX0x3sLK7iNZ32ujcSrkPBSiBr0gxkCgYEA0dWl\n' +
+  '637K41AJ/zy0FP0syq+r4eIkfqv+/t6y2aQVUBvxJYrj9ci6XHBqoxpDV8lufVYj\n' +
+  'fUAfeI9/MZaWvQJRbnYLre0I6PJfLuCBIL5eflO77BGso165AF7QJZ+fwtgKv3zv\n' +
+  'ZX75eudCSS/cFo0po9hlbcLMT4B82zEkgT8E2MECgYEAnz+3/wrdOmpLGiyL2dff\n' +
+  '3GjsqmJ2VfY8z+niSrI0BSpbD11tT9Ct67VlCBjA7hsOH6uRfpd6/kaUMzzDiFVq\n' +
+  'VDAiFvV8QD6zNkwYalQ9aFvbrvwTTPrBpjl0vamMCiJ/YC0cjq1sGr2zh3sar1Ph\n' +
+  'S43kP+s97dcZeelhaiJHVrECgYEAsx61q/loJ/LDFeYzs1cLTVn4V7I7hQY9fkOM\n' +
+  'WM0AhInVqD6PqdfXfeFYpjJdGisQ7l0BnoGGW9vir+nkcyPvb2PFRIr6+B8tsU5j\n' +
+  '7BeVgjDoUfQkcrEBK5fEBtnj/ud9BUkY8oMZZBjVNLRuI7IMwZiPvMp0rcj4zAN/\n' +
+  'LfUlpgECgYArBvFcBxSkNAzR3Rtteud1YDboSKluRM37Ey5plrn4BS0DD0jm++aD\n' +
+  '0pG2Hsik000hibw92lCkzvvBVAqF8BuAcnPlAeYfsOaa97PGEjSKEN5bJVWZ9/om\n' +
+  '9FV1axotRN2XWlwrhixZLEaagkREXhgQc540FS5O8IaI2Vpa80Atzg==\n' +
+  '-----END RSA PRIVATE KEY-----'
+
+const publicKeyPEMs = {}
+
+publicKeyPEMs['key-1'] =
+  '-----BEGIN PUBLIC KEY-----\n' +
+  'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzWSJl+Z9Bqv00FVL5N3+\n' +
+  'JCUoqmQPjIlya1BbeqQroNQ5yG1iVbYTTnMRa1zQtR6r2fNvWeg94DvxivxIG9di\n' +
+  'DMnrzijAnYlTLOl84CK2vOxkj5b68zrLH9b/Gd6NOHsywo8IjvXvCeTfca5WUHcu\n' +
+  'Vi2lT9VjygFs1ILG4RyeX1BXUumuY8fzmposxLYdMxCqUTzAn0u9Saq2H2OVj5u1\n' +
+  '14wS7OQPigu6G99dpn/iPHa3zBm87baBWDbqZWRW0BP3K6eqq8sut1+NLhNW8ADP\n' +
+  'TdnO/SO+kvXy7fqd8atSn+HlQcx6tW42dhXf3E9uE7K78eZtW0KvfyNGAjsI1Fft\n' +
+  '2QIDAQAB\n' +
+  '-----END PUBLIC KEY-----'
+
+publicKeyPEMs['key-2'] =
+  '-----BEGIN PUBLIC KEY-----\n' +
+  'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqp04VVr9OThli9b35Omz\n' +
+  'VqSfWbsoQuRrgyWsrNRn3XkFmbWw4FzZwQ42OgGMzQ84Ta4d9zGKKQyFriTiPjPf\n' +
+  'xhhrsaJnDuybcpVhcr7UNKjSZ0S59tU3hpRiEz6hO+Nc/OSSLkvalG0VKrxOln7J\n' +
+  'LK/h3rNS/l6wDZ5S/KqsI6CYtV2ZLpn3ahLrizvEYNY038Qcm38qMWx+VJAvZ4di\n' +
+  'qqmW7RLIsLT59SWmpXdhFKnkYYGhxrk1Mwl22dBTJNY5SbriU5G3gWgzYkm8pgHr\n' +
+  '6CtrXch9ciJAcDJehPrKXNvNDOdUh8EW3fekNJerF1lWcwQg44/12v8sDPyfbaKB\n' +
+  'dQIDAQAB\n' +
+  '-----END PUBLIC KEY-----'
+
+
+const obj = { 
+  '@id': 'https://example.org/personID',
+  '@type': 'https://www.w3.org/ns/activitystreams#Person',
+  'https://w3id.org/security#publicKey': {
+    '@id': 'https://example.org/personID#main-key',
+    'https://w3id.org/security#owner': 'https://example.org/personID'
+  }
+}
+let port = 8080
+let server
+let reqSpec
+
+describe('request parsed by', function () {
+
+  beforeAll(async function () {
+    server = http.createServer((req, res) => server.tester(req, res)).listen(port)
+    server.tester = (req, res) => res.writeHead(200).end('boom!')
+  })
+  afterAll(async function () {
+    return server.close()
+  })
+  beforeEach(async function () {
+    reqSpec = {
+      method: 'POST',
+      url: 'http://localhost' + (port ? ':' : '') + port + '/test',
+      headers: {
+        'Content-Type': 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+      },
+      mastodonCompatible: true,
+      httpSignature: {
+        key: privateKeyPEMs['key-1'],
+        keyId: 'key-1',
+        // algorithm: 'rsa-sha256',
+        // authorizationHeaderName: 'Signature',
+        // includeHeaders: ['(request-target)', 'host', 'date', 'digest'],
+      },
+      body: JSON.stringify(obj)
+    }
+  })
+  describe('http-signature lib', function () {
+    // * patched http-signature version fails to parse path in this case
+    // * this is correctly parsed in original http-signature
+    // * Opposite to the rest of the tests!
+
+    it('using Authorization Header', async function () {
+      reqSpec.httpSignature.authorizationHeaderName = 'Authorization'
+
+      server.tester = function (req, res) {
+        let verified = true
+        const parsed = httpSignature.parseRequest(req)
+        // uncomment to see the test pass:
+        // parsed.signingString = parsed.signingString.replace(/undefined/g, '/test');
+        // console.log(req.headers[reqSpec.httpSignature.authorizationHeaderName.toLowerCase()])
+        // console.log('Parsed with http-signature:', parsed)
+        const publicKeyPEM = publicKeyPEMs[parsed.keyId]
+        verified = httpSignature.verifySignature(parsed, publicKeyPEM)
+
+        res.writeHead(verified ? 200 : 400).end()
+      }
+
+      const result = await request(reqSpec)
+      expect(result.res.statusCode).toBe(200);
+    })
+
+    it('using Signature Header', async function () {
+      reqSpec.httpSignature.authorizationHeaderName = 'Signature'
+
+      server.tester = function (req, res) {
+        let verified = true
+        const parsed = httpSignature.parseRequest(req)
+        // uncomment to see the test pass:
+        // parsed.signingString = parsed.signingString.replace(/undefined/g, '/test');
+        // console.log('Parsed with http-signature:', parsed)
+        const publicKeyPEM = publicKeyPEMs[parsed.keyId]
+        verified = httpSignature.verifySignature(parsed, publicKeyPEM)
+
+        res.writeHead(verified ? 200 : 400).end()
+      }
+
+      const result = await request(reqSpec)
+      expect(result.res.statusCode).toBe(200);
+    })
+  })
+  describe('http-signature-header lib', function () {
+    // * http-signature-header will fail when signature header is used:
+    // * Signature: 'keyId=...'
+
+    it('using Authorization Header', async function () {
+      reqSpec.httpSignature.authorizationHeaderName = 'Authorization'
+      const signHeaderName = reqSpec.httpSignature.authorizationHeaderName.toLowerCase()
+
+      server.tester = function (req, res) {
+        let verified = true
+        const expectedHeaders = ['(request-target)', 'host', 'date', 'digest']
+        const parsed = parseRequest(
+          req, {headers: expectedHeaders, authorizationHeaderName: signHeaderName});
+        // console.log(req.headers[reqSpec.httpSignature.authorizationHeaderName.toLowerCase()])
+        // console.log('Parsed with http-signature-header:', parsed)
+        const publicKeyPEM = publicKeyPEMs[parsed.keyId]
+        verified = httpSignature.verifySignature(parsed, publicKeyPEM)
+
+        res.writeHead(verified ? 200 : 400).end()
+      }
+
+      const result = await request(reqSpec)
+      expect(result.res.statusCode).toBe(200);
+    })
+
+    it('using Signature Header', async function () {
+      reqSpec.httpSignature.authorizationHeaderName = 'Signature'
+      const signHeaderName = reqSpec.httpSignature.authorizationHeaderName.toLowerCase()
+
+      server.tester = function (req, res) {
+        let verified = true
+        const expectedHeaders = ['(request-target)', 'host', 'date', 'digest']
+        const parsed = parseRequest(
+          req, {headers: expectedHeaders, authorizationHeaderName: signHeaderName});
+        // console.log(req.headers[reqSpec.httpSignature.authorizationHeaderName.toLowerCase()])
+        // console.log('Parsed with http-signature-header:', parsed)
+        const publicKeyPEM = publicKeyPEMs[parsed.keyId]
+        verified = httpSignature.verifySignature(parsed, publicKeyPEM)
+
+        res.writeHead(verified ? 200 : 400).end()
+      }
+
+      const result = await request(reqSpec)
+      expect(result.res.statusCode).toBe(200);
+    })
+  })
+
+})


### PR DESCRIPTION
This PR implements `request-compose` based replacement for old/deprecated `request` + `request-promise-native` libraries as discussed in #12

This change also starts work toward replacing patched version of `http-signature` with maintained alternative. 

But here it gets complicated as all of available libraries have some problems, here is a list of some pros/cons

* `http-signature` (joyent)
  * (+) has sign/verifySignature implemented, parseRequest with no spec
  * (-) doesn't work with 'Signature' header
  * (-) operates on request object only
  * (-) incorrect path parsing: path -> undefined
  * (-) inactive
* `http-signature` (patched)
  * (+) has sign/verifySignature implemented, parseRequest with no spec
  * (-) operates on request object only
  * (-) edge case incorrect path parsing: path -> undefined
  * (-) is patched
* `http-signature-header` (digitalbazaar)
  * (+) operates on headers directly
  * (+) more active/recent than joyent
  * (-/+) (-) custom methods need to be implemented; (+) flexibility
  * (-/+) parseRequest requires specification for parsing
  * (-) doesn't work correctly with 'Signature' header (inherits problem from joyent)
  * (?) possibly the same path parsing problem may apply here.

I think the best way forward (long term) is to fix `http-signature-header` and implement missing methods. 
In the interim use `http-signature-header` for signing and `http-signature` (patched, fixed) for parsing and verifying

In both interim and long term as of now we can remove old  `request` + `request-promise-native` as dependencies.

Tasks:
- [x] request replacement implemented
- [ ] (http-signature patched) fix edge case path parsing
- [ ] (http-signature-header) fix parseRequest for headers: `Signature: 'keyId=.....`

