### PR TITLE
Fix TimeoutOverflowWarning

### DIFF
--- a/pub/federation.js
+++ b/pub/federation.js
@@ -11,7 +11,7 @@ module.exports = {
   runDelivery,
   startDelivery
 }
-
+const maxTimeout = Math.pow(2, 31) - 1
 let isDelivering = false
 let nextDelivery = null
 
@@ -107,7 +107,7 @@ async function runDelivery () {
   }
   // only future-dated items left, resume then
   if (toDeliver.waitUntil) {
-    const wait = toDeliver.waitUntil.getTime() - Date.now()
+    const wait = Math.min(toDeliver.waitUntil.getTime() - Date.now(), maxTimeout)
     nextDelivery = setTimeout(() => this.startDelivery(), wait)
     isDelivering = false
     return


### PR DESCRIPTION
Avoid timer overflow because setTimeout maxes out at ~24 days. Delivery retries will still last 5 months, but the delivery process will boot up and go back to sleep once a month during that final 4 month delay (if no other delivery activity occurs)