### PR TITLE
Misc reliability fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ store | Replace the default storage model & database backend with your own (see 
 threadDepth | Controls how far up apex will follow links in incoming activities in order to display the conversation thread & check for inbox forwarding needs  (default 10)
 systemUser | Actor object representing system and used for signing GETs (see below)
 offlineMode | Disable delivery. Useful for running migrations and queueing deliveries to be sent when app is running
+requestTimeout | Timeout for requests to other servers, ms (default 5000)
 
 Blocked, rejections, and rejected: these routes must be defined in order to track
 these items internally for each actor, but they do not need to be exposed endpoints

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ module.exports = function (settings) {
   apex.systemUser = settings.systemUser
   apex.logger = settings.logger || console
   apex.offlineMode = settings.offlineMode
+  apex.requestTimeout = settings.requestTimeout ?? 5000
   apex.utils = {
     usernameToIRI: apex.idToIRIFactory(apex.domain, settings.routes.actor, apex.actorParam),
     objectIdToIRI: apex.idToIRIFactory(apex.domain, settings.routes.object, apex.objectParam),

--- a/index.js
+++ b/index.js
@@ -56,7 +56,9 @@ module.exports = function (settings) {
   function onFinishedHandler (err, res) {
     if (err) return
     const apexLocal = res.locals.apex
-    Promise.all(apexLocal.postWork.map(task => task.call(res)))
+    // execute postWork tasks in sequence (not parallel)
+    apexLocal.postWork
+      .reduce((acc, task) => acc.then(() => task(res)), Promise.resolve())
       .then(() => {
         if (apexLocal.eventName) {
           res.app.emit(apexLocal.eventName, apexLocal.eventMessage)

--- a/net/validators.js
+++ b/net/validators.js
@@ -116,14 +116,13 @@ function inboxActivity (req, res, next) {
       return next()
     }
   } else if (type === 'accept') {
-    // the activity being accepted was sent to the actor trying to accept it
-    if (!object.to.includes(actor.id)) {
-      resLocal.status = 403
-      return next()
-    }
     // for follows, also confirm the follow object was the actor trying to accept it
     const isFollow = object.type.toLowerCase() === 'follow'
     if (isFollow && !apex.validateTarget(object, actor.id)) {
+      resLocal.status = 403
+      return next()
+    } else if (!isFollow && !object.to?.includes(actor.id)) {
+      // the activity being accepted was sent to the actor trying to accept it
       resLocal.status = 403
       return next()
     }
@@ -360,14 +359,13 @@ function outboxActivity (req, res, next) {
     return next()
   }
   if (type === 'accept') {
-    // the activity being accepted was sent to the actor trying to accept it
-    if (!object.to.includes(actor.id)) {
-      resLocal.status = 403
-      return next()
-    }
-    // for follows, also confirm the follow object was the actor trying to accept it
+    // for follows, confirm the follow object was the actor trying to accept it
     const isFollow = object.type.toLowerCase() === 'follow'
     if (isFollow && !apex.validateTarget(object, actor.id)) {
+      resLocal.status = 403
+      return next()
+    } else if (!isFollow && !object.to?.includes(actor.id)) {
+      // for other accepts, check the activity being accepted was sent to the actor trying to accept it
       resLocal.status = 403
       return next()
     }

--- a/pub/federation.js
+++ b/pub/federation.js
@@ -22,7 +22,8 @@ function requestObject (id) {
   const req = {
     url: id,
     headers: { Accept: 'application/activity+json' },
-    json: true
+    json: true,
+    timeout: this.requestTimeout
   }
   if (this.systemUser) {
     req.httpSignature = {
@@ -78,6 +79,7 @@ function deliver (actorId, activity, address, signingKey) {
     },
     resolveWithFullResponse: true,
     simple: false,
+    timeout: this.requestTimeout,
     body: activity
   })
 }

--- a/pub/utils.js
+++ b/pub/utils.js
@@ -351,12 +351,13 @@ async function jsonldContextLoader (url, options) {
   const context = await nodeDocumentLoader(url)
   if (context && context.document) {
     try {
+      // save original url in case of redirects
+      context.documentUrl = url
       await this.store.saveContext(context)
     } catch (err) {
       this.logger.error('Error saving jsonld contact cache', err.message)
     }
   }
-  // call the default documentLoader
   return context
 }
 

--- a/spec/functional/inbox.spec.js
+++ b/spec/functional/inbox.spec.js
@@ -331,7 +331,23 @@ describe('inbox', function () {
           .expect(200)
           .end(err => { if (err) done(err) })
       })
+      it('handles accept to follow without a to field', async function (done) {
+        delete follow.to
+        await apex.store.saveActivity(follow)
+        app.once('apex-inbox', msg => {
+          expect(msg.object.id).toEqual(follow.id)
+          expect(msg.object._meta.collection).toContain(testUser.following[0])
+          done()
+        })
+        request(app)
+          .post('/inbox/test')
+          .set('Content-Type', 'application/activity+json')
+          .send(accept)
+          .expect(200)
+          .end(err => { if (err) done(err) })
+      })
       it('rejects accept from non-recipients of original activity', async function (done) {
+        follow.type = 'Offer'
         follow.to = ['https://ignore.com/sally']
         await apex.store.saveActivity(follow)
         app.once('apex-inbox', msg => {

--- a/spec/helpers/nocks.js
+++ b/spec/helpers/nocks.js
@@ -1,18 +1,6 @@
-/* global beforeAll, afterAll */
-const fs = require('fs')
+/* global beforeEach, afterEach */
 const nock = require('nock')
-const activities = fs.readFileSync('vocab/as.json')
-const security = fs.readFileSync('vocab/security.json')
-beforeAll(() => {
-  nock('https://www.w3.org')
-    .get('/ns/activitystreams')
-    .reply(200, activities)
-    .persist(true)
-  nock('https://w3id.org')
-    .get('/security/v1')
-    .reply(200, security)
-    .persist(true)
-  // block federation attempts
+beforeEach(() => {
   nock('https://ignore.com')
     .get(uri => uri.startsWith('/s/'))
     .reply(200, uri => ({ id: `https://ignore.com${uri}`, type: 'Activity', actor: 'https://ignore.com/u/bob' }))
@@ -24,6 +12,6 @@ beforeAll(() => {
     .reply(200)
     .persist()
 })
-afterAll(() => {
+afterEach(() => {
   nock.cleanAll()
 })

--- a/spec/unit/utils.spec.js
+++ b/spec/unit/utils.spec.js
@@ -57,7 +57,7 @@ describe('utils', function () {
         contextUrl: null
       })
     })
-    it('fetches and caches new contexts', async function () {
+    it('caches redirected contexts by original url', async function () {
       nock('https://mocked.com')
         .get('/context/v1')
         .reply(302, undefined, {

--- a/spec/unit/utils.spec.js
+++ b/spec/unit/utils.spec.js
@@ -57,6 +57,34 @@ describe('utils', function () {
         contextUrl: null
       })
     })
+    it('fetches and caches new contexts', async function () {
+      nock('https://mocked.com')
+        .get('/context/v1')
+        .reply(302, undefined, {
+          Location: 'http://redirect.com/context/v1'
+        })
+      nock('http://redirect.com')
+        .get('/context/v1')
+        .reply(200, context)
+      const doc = {
+        '@context': 'https://mocked.com/context/v1',
+        id: 'https://mocked.com/s/abc123',
+        customProp: 'https://mocked.com/s/123abc'
+      }
+      const ld = await apex.toJSONLD(doc)
+      expect(ld).toEqual({
+        '@context': apex.context,
+        id: 'https://mocked.com/s/abc123',
+        'https://mocked.com/context/v1#customProp': {
+          id: 'https://mocked.com/s/123abc'
+        }
+      })
+      expect(await apex.store.getContext('https://mocked.com/context/v1')).toEqual({
+        documentUrl: 'https://mocked.com/context/v1',
+        document: JSON.stringify(context),
+        contextUrl: null
+      })
+    })
     it('uses cached context', async function () {
       await apex.store.saveContext({
         documentUrl: 'https://mocked.com/context/v1',


### PR DESCRIPTION
Fixes for a couple big issues I found this week:

1. immers.space posts not being delivered in a timely manner due to long pauses waiting for now-defunct medieval-castle.club to respond
2. All of our immers going down when the w3c-ccg security vocabulary went down (w3c-ccg/security-vocab#107) because we were using a redirected url as the cache key instead of the original, so it ended up refetching every time

* Reduce request timeouts to fix delivery queue buildup when a dead server is in follows
* Fix a context caching bug that forcing fresh fetches of security context on every json-ld operation
* Keep the two core json-ld contexts in memory to reduce disk reads
* Fix a race condition in post-work tasks that could cause new followers to miss an update
* Remove validation requirement for Follow activities to have a `to` field so that we can accept follows from Mastodon
* Fix cascading failures from tests due to inadequate isolation of request mocks