### PR TITLE
Allow apps to apply custom queries/aggregations to collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+# Added
+
+* getCollection gains optional `query` argument which is passsed
+through to store.getStream to allow additional filtering or
+aggregation to be applied
 ## v3.2.0 (2022-06-23)
 
 * Undo activity can now take a blocked user IRI as its object and will resolve to that block activity to allow easily unblocking withough knowing the original block activity IRI

--- a/pub/collection.js
+++ b/pub/collection.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const overlaps = require('overlaps')
-
 module.exports = {
   buildCollection,
   buildCollectionPage,
@@ -38,12 +36,17 @@ async function buildCollectionPage (collectionId, page, isOrdered, lastItemId) {
   })
 }
 
-/* page: MongoDB _id of item to begin querying after (i.e. last item of last page) or
- *  one of two special values:
- *    'true' - get first page
- *    Infinity - get all items (internal use only)
+/**
+ * Get a collection object or collection page objct
+ * @param  {string} collectionId
+ * @param  {string | Infinity} [page] MongoDB _id of item to begin querying after (i.e. last item of last page)
+ *   or one of two special values: 'true' - get first page, Infinity - get all items (internal use only)
+ * @param  {function} [remapper]
+ * @param  {boolean} [includePrivate]
+ * @param  {string[]} [blockList]
+ * @param  {object[]} [query] - additional filtering/aggregation passed through to store.getStream
  */
-async function getCollection (collectionId, page, remapper, includePrivate, blockList) {
+async function getCollection (collectionId, page, remapper, includePrivate, blockList, query) {
   collectionId = this.objectIdFromValue(collectionId)
   if (!page) {
     // if page isn't specified, just collection description is served
@@ -59,7 +62,7 @@ async function getCollection (collectionId, page, remapper, includePrivate, bloc
     after = null
     limit = null
   }
-  let stream = await this.store.getStream(collectionId, limit, after, blockList)
+  let stream = await this.store.getStream(collectionId, limit, after, blockList, query)
   const pageObj = await this.buildCollectionPage(
     collectionId,
     page,

--- a/store/index.js
+++ b/store/index.js
@@ -180,7 +180,8 @@ class ApexStore extends IApexStore {
    * Return a specific collection (stream of activitites), e.g. a user's inbox
    * @param  {string} collectionId - _meta.collection identifier
    * @param  {number} limit - max number of activities to return
-   * @param  {string} after - mongodb _id to begin querying after (i.e. last item of last page)
+   * @param  {string} [after] - mongodb _id to begin querying after (i.e. last item of last page)
+   * @param  {string[]} [blockList] - list of ids of actors whose activities should be excluded
    * @param  {object[]} [query] - additional aggretation pipeline stages to include
    * @returns {Promise<object[]>}
    */

--- a/store/index.js
+++ b/store/index.js
@@ -176,7 +176,15 @@ class ApexStore extends IApexStore {
       .replaceOne({ documentUrl }, context, { forceServerObjectId: true, upsert: true })
   }
 
-  getStream (collectionId, limit, after, blockList) {
+  /**
+   * Return a specific collection (stream of activitites), e.g. a user's inbox
+   * @param  {string} collectionId - _meta.collection identifier
+   * @param  {number} limit - max number of activities to return
+   * @param  {string} after - mongodb _id to begin querying after (i.e. last item of last page)
+   * @param  {object[]} [query] - additional aggretation pipeline stages to include
+   * @returns {Promise<object[]>}
+   */
+  getStream (collectionId, limit, after, blockList, query) {
     const pipeline = []
     const filter = { '_meta.collection': collectionId }
     if (after) {
@@ -186,6 +194,9 @@ class ApexStore extends IApexStore {
       filter.actor = { $nin: blockList }
     }
     pipeline.push({ $match: filter })
+    if (query) {
+      pipeline.push(...query)
+    }
     pipeline.push({ $sort: { _id: -1 } })
     if (limit) {
       pipeline.push({ $limit: limit })
@@ -210,8 +221,8 @@ class ApexStore extends IApexStore {
       }
     })
 
-    const query = this.db.collection('streams').aggregate(pipeline)
-    return query.toArray().then(stream => unescape(stream))
+    const result = this.db.collection('streams').aggregate(pipeline)
+    return result.toArray().then(stream => unescape(stream))
   }
 
   getStreamCount (collectionId) {

--- a/store/interface.js
+++ b/store/interface.js
@@ -27,7 +27,15 @@ module.exports = class IApexStore {
     throw new Error('Not implemented')
   }
 
-  getStream (collectionId, limit, after) {
+  /**
+   * Return a specific collection (stream of activitites), e.g. a user's inbox
+   * @param  {string} collectionId - collection identifier
+   * @param  {number} limit - max number of activities to return
+   * @param  {string} after - id to begin querying after (i.e. last item of last page)
+   * @param  {any} [query] - additional query/aggregation
+   * @returns Promse<object[]>
+   */
+  getStream (collectionId, limit, after, query) {
     throw new Error('Not implemented')
   }
 

--- a/store/interface.js
+++ b/store/interface.js
@@ -31,11 +31,12 @@ module.exports = class IApexStore {
    * Return a specific collection (stream of activitites), e.g. a user's inbox
    * @param  {string} collectionId - collection identifier
    * @param  {number} limit - max number of activities to return
-   * @param  {string} after - id to begin querying after (i.e. last item of last page)
+   * @param  {string} [after] - id to begin querying after (i.e. last item of last page)
+   * @param  {string[]} [blockList] - list of ids of actors whose activities should be excluded
    * @param  {any} [query] - additional query/aggregation
-   * @returns Promse<object[]>
+   * @returns {Promise<object[]>}
    */
-  getStream (collectionId, limit, after, query) {
+  getStream (collectionId, limit, after, blockList, query) {
     throw new Error('Not implemented')
   }
 


### PR DESCRIPTION
add a passthrough arg to getcollection that the storage driver can use to facilitate custom query/aggregations from the consuming app