### PR TITLE
Unit test updates.

### DIFF
--- a/spec/functional/collections.spec.js
+++ b/spec/functional/collections.spec.js
@@ -62,6 +62,7 @@ describe('collections', function () {
         .set('Accept', 'application/activity+json')
         .expect(200)
         .end(function (err, res) {
+          if (err) done.fail(err)
           const standard = {
             '@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'],
             id: 'https://localhost/followers/test',
@@ -70,7 +71,7 @@ describe('collections', function () {
             first: 'https://localhost/followers/test?page=true'
           }
           expect(res.body).toEqual(standard)
-          done(err)
+          done()
         })
     })
     it('page returns accepted followers', function (done) {
@@ -79,6 +80,7 @@ describe('collections', function () {
         .set('Accept', 'application/activity+json')
         .expect(200)
         .end(function (err, res) {
+          if (err) done.fail(err)
           const standard = {
             '@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'],
             id: 'https://localhost/followers/test?page=true',
@@ -89,7 +91,7 @@ describe('collections', function () {
 
           }
           expect(res.body).toEqual(standard)
-          done(err)
+          done()
         })
     })
   })
@@ -111,12 +113,13 @@ describe('collections', function () {
       firstActivity = await apex.store.db.collection('streams')
         .findOne({}, { sort: { _id: 1 } })
     })
-    it('returns following collection', async function (done) {
+    it('returns following collection', function (done) {
       request(app)
         .get('/following/test')
         .set('Accept', 'application/activity+json')
         .expect(200)
         .end(function (err, res) {
+          if (err) done.fail(err)
           const standard = {
             '@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'],
             id: 'https://localhost/following/test',
@@ -125,15 +128,16 @@ describe('collections', function () {
             first: 'https://localhost/following/test?page=true'
           }
           expect(res.body).toEqual(standard)
-          done(err)
+          done()
         })
     })
-    it('page returns accepted following', async function (done) {
+    it('page returns accepted following', function (done) {
       request(app)
         .get('/following/test?page=true')
         .set('Accept', 'application/activity+json')
         .expect(200)
         .end(function (err, res) {
+          if (err) done.fail(err)
           const standard = {
             '@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'],
             id: 'https://localhost/following/test?page=true',
@@ -143,7 +147,7 @@ describe('collections', function () {
             next: `https://localhost/following/test?page=${firstActivity._id}`
           }
           expect(res.body).toEqual(standard)
-          done(err)
+          done()
         })
     })
   })
@@ -163,12 +167,13 @@ describe('collections', function () {
       firstActivity = await apex.store.db.collection('streams')
         .findOne({}, { sort: { _id: 1 } })
     })
-    it('returns liked collection', async function (done) {
+    it('returns liked collection', function (done) {
       request(app)
         .get('/liked/test')
         .set('Accept', 'application/activity+json')
         .expect(200)
         .end(function (err, res) {
+          if (err) done.fail(err)
           const standard = {
             '@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'],
             id: 'https://localhost/liked/test',
@@ -177,15 +182,16 @@ describe('collections', function () {
             first: 'https://localhost/liked/test?page=true'
           }
           expect(res.body).toEqual(standard)
-          done(err)
+          done()
         })
     })
-    it('page returns liked objects', async function (done) {
+    it('page returns liked objects', function (done) {
       request(app)
         .get('/liked/test?page=true')
         .set('Accept', 'application/activity+json')
         .expect(200)
         .end(function (err, res) {
+          if (err) done.fail(err)
           const standard = {
             '@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'],
             id: 'https://localhost/liked/test?page=true',
@@ -195,7 +201,7 @@ describe('collections', function () {
             orderedItems: ['https://ignore.com/s/3', 'https://ignore.com/s/2', 'https://ignore.com/s/1']
           }
           expect(res.body).toEqual(standard)
-          done(err)
+          done()
         })
     })
   })
@@ -211,7 +217,7 @@ describe('collections', function () {
         })
         expect(act.shares).toEqual([await apex.getShares(act)])
       })
-      it('get page returns announces for activity', async function (done) {
+      it('get page returns announces for activity', async function () {
         const act = await apex.buildActivity('Create', testUser.id, testUser.followers, {
           object: {
             id: apex.utils.objectIdToIRI(),
@@ -225,16 +231,13 @@ describe('collections', function () {
         await apex.addMeta(announce, 'collection', apex.objectIdFromValue(act.shares))
         await apex.store.saveActivity(act)
         await apex.store.saveActivity(announce)
-        request(app)
+        const res = await request(app)
           .get(`${act.id}/shares?page=true`.replace('https://localhost', ''))
           .set('Accept', 'application/activity+json')
           .expect(200)
-          .end(async function (err, res) {
-            const standard = await global.toExternalJSONLD(apex, announce, true)
-            standard.actor = actors.find(act => act.id === announce.actor[0])
-            expect(res.body.orderedItems).toEqual([standard])
-            done(err)
-          })
+        const standard = await global.toExternalJSONLD(apex, announce, true)
+        standard.actor = actors.find(act => act.id === announce.actor[0])
+        expect(res.body.orderedItems).toEqual([standard])
       })
     })
     describe('likes', function () {
@@ -248,7 +251,7 @@ describe('collections', function () {
         })
         expect(act.likes).toEqual([await apex.getLikes(act)])
       })
-      it('returns likes for activity', async function (done) {
+      it('returns likes for activity', async function () {
         const act = await apex.buildActivity('Create', testUser.id, testUser.followers, {
           object: {
             id: apex.utils.objectIdToIRI(),
@@ -262,21 +265,18 @@ describe('collections', function () {
         await apex.addMeta(like, 'collection', apex.objectIdFromValue(act.likes))
         await apex.store.saveActivity(act)
         await apex.store.saveActivity(like)
-        request(app)
+        const res = await request(app)
           .get(`${act.id}/likes?page=true`.replace('https://localhost', ''))
           .set('Accept', 'application/activity+json')
           .expect(200)
-          .end(async function (err, res) {
-            const standard = await global.toExternalJSONLD(apex, like, true)
-            standard.actor = actors.find(act => act.id === like.actor[0])
-            expect(res.body.orderedItems).toEqual([standard])
-            done(err)
-          })
+        const standard = await global.toExternalJSONLD(apex, like, true)
+        standard.actor = actors.find(act => act.id === like.actor[0])
+        expect(res.body.orderedItems).toEqual([standard])
       })
     })
   })
   describe('misc collections', function () {
-    it('gets collection items', async function (done) {
+    it('gets collection items', async function () {
       const col = `${testUser.id}/c/cool-stuff`
       const act = await apex.buildActivity('Create', testUser.id, testUser.followers, {
         object: {
@@ -290,14 +290,11 @@ describe('collections', function () {
         .toExternalJSONLD(apex, apex.mergeJSONLD(act, { actor: [testUser] }), true)
       apex.addMeta(act, 'collection', col)
       await apex.store.saveActivity(act)
-      request(app)
+      const res = await request(app)
         .get(`${col.replace('https://localhost', '')}?page=true`)
         .set('Accept', 'application/activity+json')
         .expect(200)
-        .end(function (err, res) {
-          expect(res.body.orderedItems).toEqual([actOut])
-          done(err)
-        })
+      expect(res.body.orderedItems).toEqual([actOut])
     })
   })
   describe('internal special collections', function () {
@@ -343,29 +340,27 @@ describe('collections', function () {
       const rejected = await apex.getRejected(testUser, Infinity, true)
       expect(rejected.orderedItems).toEqual(follows.map(a => a.id).reverse())
     })
-    it('blocked c2s endpoint returns collection', async function (done) {
-      request(app)
+    it('blocked c2s endpoint returns collection', async function () {
+      const res = await request(app)
         .get('/u/test/blocked')
         .set('Accept', 'application/activity+json')
         .expect(200)
-        .end(function (err, res) {
-          const standard = {
-            '@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'],
-            id: 'https://localhost/u/test/blocked',
-            type: 'OrderedCollection',
-            totalItems: 0,
-            first: 'https://localhost/u/test/blocked?page=true'
-          }
-          expect(res.body).toEqual(standard)
-          done(err)
-        })
+      const standard = {
+        '@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'],
+        id: 'https://localhost/u/test/blocked',
+        type: 'OrderedCollection',
+        totalItems: 0,
+        first: 'https://localhost/u/test/blocked?page=true'
+      }
+      expect(res.body).toEqual(standard)
     })
-    it('rejected c2s endpoint returns collection', async function (done) {
+    it('rejected c2s endpoint returns collection', function (done) {
       request(app)
         .get('/u/test/rejected')
         .set('Accept', 'application/activity+json')
         .expect(200)
         .end(function (err, res) {
+          if (err) done.fail(err)
           const standard = {
             '@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'],
             id: 'https://localhost/u/test/rejected',
@@ -374,15 +369,16 @@ describe('collections', function () {
             first: 'https://localhost/u/test/rejected?page=true'
           }
           expect(res.body).toEqual(standard)
-          done(err)
+          done()
         })
     })
-    it('rejections c2s endpoint returns collection', async function (done) {
+    it('rejections c2s endpoint returns collection', function (done) {
       request(app)
         .get('/u/test/rejections')
         .set('Accept', 'application/activity+json')
         .expect(200)
         .end(function (err, res) {
+          if (err) done.fail(err)
           const standard = {
             '@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'],
             id: 'https://localhost/u/test/rejections',
@@ -391,7 +387,7 @@ describe('collections', function () {
             first: 'https://localhost/u/test/rejections?page=true'
           }
           expect(res.body).toEqual(standard)
-          done(err)
+          done()
         })
     })
   })

--- a/spec/functional/inbox.spec.js
+++ b/spec/functional/inbox.spec.js
@@ -109,7 +109,8 @@ describe('inbox', function () {
       request(app)
         .post('/inbox/test')
         .send({})
-        .expect(404, done)
+        .expect(404)
+        .end(err => global.failOrDone(err, done))
     })
     // validators activity
     it('errors invalid activities', function (done) {
@@ -117,7 +118,7 @@ describe('inbox', function () {
         .post('/inbox/test')
         .set('Content-Type', 'application/activity+json')
         .send({ actor: 'https://ignore.com/bob', '@context': 'https://www.w3.org/ns/activitystreams' })
-        .expect(400, 'Invalid activity', done)
+        .expect(400, 'Invalid activity', err => global.failOrDone(err, done))
     })
     // activity getTargetActor
     it('errors on unknown actor', function (done) {
@@ -125,7 +126,7 @@ describe('inbox', function () {
         .post('/inbox/noone')
         .set('Content-Type', 'application/activity+json')
         .send(activity)
-        .expect(404, '\'noone\' not found on this instance', done)
+        .expect(404, '\'noone\' not found on this instance', err => global.failOrDone(err, done))
     })
     // activity save
     it('saves activity', function (done) {
@@ -146,7 +147,7 @@ describe('inbox', function () {
           expect(act).toEqual(activityNormalized)
           done()
         })
-        .catch(done)
+        .catch(err => global.failOrDone(err, done))
     })
     it('resolves and embeds activity collections', function (done) {
       const act = merge({}, activity)
@@ -197,29 +198,25 @@ describe('inbox', function () {
           done()
         })
     })
-    it('consolidates repeated deliveries', async function (done) {
+    it('consolidates repeated deliveries', async function () {
       const first = merge({ _meta: { collection: ['https://localhost/u/bob'] } }, activityNormalized)
       await apex.store.saveActivity(first)
-      request(app)
+      await request(app)
         .post('/inbox/test')
         .set('Content-Type', 'application/activity+json')
         .send(activity)
         .expect(200)
-        .then(() => {
-          return apex.store.db
-            .collection('streams')
-            .findOne({ id: activity.id })
-        })
-        .then(act => {
-          expect(act._meta.collection).toEqual([
-            'https://localhost/u/bob',
-            'https://localhost/inbox/test'
-          ])
-          done()
-        })
-        .catch(done)
+
+      const act = await apex.store.db
+        .collection('streams')
+        .findOne({ id: activity.id })
+
+      expect(act._meta.collection).toEqual([
+        'https://localhost/u/bob',
+        'https://localhost/inbox/test'
+      ])
     })
-    it('ignores blocked actors', async function (done) {
+    it('ignores blocked actors', async function () {
       const block = merge({}, activityNormalized)
       block.type = 'Block'
       block.object = ['https://ignore.com/u/chud']
@@ -228,19 +225,15 @@ describe('inbox', function () {
       await apex.store.saveActivity(block)
       const act = merge({}, activity)
       act.actor = ['https://ignore.com/u/chud']
-      request(app)
+      await request(app)
         .post('/inbox/test')
         .set('Content-Type', 'application/activity+json')
         .send(act)
         .expect(200)
-        .end(async (err) => {
-          if (err) return done(err)
-          const inbox = await apex.getInbox(testUser, Infinity, true)
-          expect(inbox.orderedItems.length).toBe(0)
-          done()
-        })
+      const inbox = await apex.getInbox(testUser, Infinity, true)
+      expect(inbox.orderedItems.length).toBe(0)
     })
-    it('forwards from inbox', async function (done) {
+    it('forwards from inbox', async function () {
       const mockedUser = 'https://mocked.com/u/mocked'
       spyOn(apex, 'getFollowers').and
         .resolveTo({ orderedItems: [{ id: mockedUser, type: 'Actor', inbox: ['https://mocked.com/inbox/mocked'] }] })
@@ -252,18 +245,20 @@ describe('inbox', function () {
         { object: { id: 'https://ignore.com/o/abc123', type: 'Note', inReplyTo: activityNormalized.id } }
       )
       reply.id = 'https://ignore.com/s/123abc'
-      nock('https://mocked.com').post('/inbox/mocked')
-        .reply(200)
-        .on('request', (req, interceptor, body) => {
-          expect(JSON.parse(body).id).toBe('https://ignore.com/s/123abc')
-          done()
-        })
-      request(app)
+      const requestValidated = new Promise(resolve => {
+        nock('https://mocked.com').post('/inbox/mocked')
+          .reply(200)
+          .on('request', (req, interceptor, body) => {
+            expect(JSON.parse(body).id).toBe('https://ignore.com/s/123abc')
+            resolve()
+          })
+      })
+      await request(app)
         .post('/inbox/test')
         .set('Content-Type', 'application/activity+json')
         .send(await apex.toJSONLD(reply))
         .expect(200)
-        .end(err => { if (err) done(err) })
+      await requestValidated
     })
     // activity sideEffects
     it('fires create event', function (done) {
@@ -280,7 +275,7 @@ describe('inbox', function () {
         .set('Content-Type', 'application/activity+json')
         .send(activity)
         .expect(200)
-        .end(err => { if (err) done(err) })
+        .end(err => global.failIfError(err, done))
     })
     it('saves created object', function (done) {
       request(app)
@@ -298,7 +293,7 @@ describe('inbox', function () {
           expect(obj).toEqual(activityNormalized.object[0])
           done()
         })
-        .catch(done)
+        .catch(err => global.failOrDone(err, done))
     })
     describe('accept', function () {
       let follow
@@ -319,120 +314,120 @@ describe('inbox', function () {
           object: follow.id
         }
       })
-      it('fires accept event', async function (done) {
+      it('fires accept event', async function () {
         await apex.store.saveActivity(follow)
-        app.once('apex-inbox', msg => {
-          expect(msg.object.id).toEqual(follow.id)
-          expect(msg.object._meta.collection).toContain(testUser.following[0])
-          done()
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-inbox', msg => {
+            expect(msg.object.id).toEqual(follow.id)
+            expect(msg.object._meta.collection).toContain(testUser.following[0])
+            resolve()
+          })
         })
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(accept)
           .expect(200)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
-      it('handles accept to follow without a to field', async function (done) {
+      it('handles accept to follow without a to field', async function () {
         delete follow.to
         await apex.store.saveActivity(follow)
-        app.once('apex-inbox', msg => {
-          expect(msg.object.id).toEqual(follow.id)
-          expect(msg.object._meta.collection).toContain(testUser.following[0])
-          done()
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-inbox', msg => {
+            expect(msg.object.id).toEqual(follow.id)
+            expect(msg.object._meta.collection).toContain(testUser.following[0])
+            resolve()
+          })
         })
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(accept)
           .expect(200)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
-      it('rejects accept from non-recipients of original activity', async function (done) {
+      it('rejects accept from non-recipients of original activity', async function () {
         follow.type = 'Offer'
         follow.to = ['https://ignore.com/sally']
         await apex.store.saveActivity(follow)
-        app.once('apex-inbox', msg => {
-          expect(msg.object.id).toEqual(follow.id)
-          done()
-        })
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(accept)
-          .expect(403, done)
+          .expect(403)
       })
-      it('rejects accept from non-target of original follow', async function (done) {
+      it('rejects accept from non-target of original follow', async function () {
         follow.object = ['https://ignore.com/sally']
         await apex.store.saveActivity(follow)
-        app.once('apex-inbox', msg => {
-          expect(msg.object.id).toEqual(follow.id)
-          done()
-        })
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(accept)
-          .expect(403, done)
+          .expect(403)
       })
-      it('updates accepted activity', async function (done) {
-        app.once('apex-inbox', async () => {
-          const updated = await apex.store.db.collection('streams').findOne({ id: follow.id })
-          expect(updated._meta.collection).toEqual([testUser.outbox[0], testUser.following[0]])
-          done()
+      it('updates accepted activity', async function () {
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-inbox', async () => {
+            const updated = await apex.store.db.collection('streams').findOne({ id: follow.id })
+            expect(updated._meta.collection).toEqual([testUser.outbox[0], testUser.following[0]])
+            resolve()
+          })
         })
         await apex.store.saveActivity(follow)
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(accept)
           .expect(200)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
-      it('publishes collection update', async function (done) {
+      it('publishes collection update', async function () {
         const mockedUser = 'https://mocked.com/user/mocked'
         nock('https://mocked.com')
           .get('/user/mocked')
           .reply(200, { id: mockedUser, type: 'Actor', inbox: 'https://mocked.com/inbox/mocked' })
-        nock('https://mocked.com').post('/inbox/mocked')
-          .reply(200)
-          .on('request', async (req, interceptor, body) => {
-            const sentActivity = JSON.parse(body)
-            expect(sentActivity.id).toContain('https://localhost')
-            // update activity appears in outbox
-            const update = await apex.store.getActivity(sentActivity.id, true)
-            expect(update._meta.collection).toContain(testUser.outbox[0])
-            // correctly formed activity sent
-            delete sentActivity.id
-            delete sentActivity.likes
-            delete sentActivity.shares
-            expect(new Date(sentActivity.published).toString()).not.toBe('Invalid Date')
-            delete sentActivity.published
-            expect(sentActivity).toEqual({
-              '@context': apex.context,
-              type: 'Update',
-              actor: testUser.id,
-              to: 'https://localhost/followers/test',
-              cc: 'https://mocked.com/user/mocked',
-              object: {
-                id: testUser.following[0],
-                type: 'OrderedCollection',
-                totalItems: 1,
-                first: 'https://localhost/following/test?page=true'
-              }
+        const requestValidated = new Promise(resolve => {
+          nock('https://mocked.com').post('/inbox/mocked')
+            .reply(200)
+            .on('request', async (req, interceptor, body) => {
+              const sentActivity = JSON.parse(body)
+              expect(sentActivity.id).toContain('https://localhost')
+              // update activity appears in outbox
+              const update = await apex.store.getActivity(sentActivity.id, true)
+              expect(update._meta.collection).toContain(testUser.outbox[0])
+              // correctly formed activity sent
+              delete sentActivity.id
+              delete sentActivity.likes
+              delete sentActivity.shares
+              expect(new Date(sentActivity.published).toString()).not.toBe('Invalid Date')
+              delete sentActivity.published
+              expect(sentActivity).toEqual({
+                '@context': apex.context,
+                type: 'Update',
+                actor: testUser.id,
+                to: 'https://localhost/followers/test',
+                cc: 'https://mocked.com/user/mocked',
+                object: {
+                  id: testUser.following[0],
+                  type: 'OrderedCollection',
+                  totalItems: 1,
+                  first: 'https://localhost/following/test?page=true'
+                }
+              })
+              resolve()
             })
-            done()
-          })
+        })
         follow.to = [mockedUser]
         follow.object = [mockedUser]
         accept.actor = mockedUser
         await apex.store.saveActivity(follow)
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(accept)
           .expect(200)
-          .end(err => { if (err) done(err) })
+        await requestValidated
       })
     })
     it('fires follow event', function (done) {
@@ -452,7 +447,7 @@ describe('inbox', function () {
         .set('Content-Type', 'application/activity+json')
         .send(follow)
         .expect(200)
-        .end(err => { if (err) done(err) })
+        .end(err => global.failIfError(err, done))
     })
     describe('undo', function () {
       let undo
@@ -468,28 +463,30 @@ describe('inbox', function () {
           object: undone.id
         }
       })
-      it('fires undo event', async function (done) {
+      it('fires undo event', async function () {
         await apex.store.saveActivity(undone)
-        app.once('apex-inbox', () => {
-          done()
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-inbox', () => {
+            resolve()
+          })
         })
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(undo)
           .expect(200)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
-      it('rejects undo with owner mismatch', async function (done) {
+      it('rejects undo with owner mismatch', async function () {
         undone.actor = ['https://ignore.com/bob']
         await apex.store.saveActivity(undone)
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(undo)
-          .expect(403, done)
+          .expect(403)
       })
-      it('removes undone activity', async function (done) {
+      it('removes undone activity', async function () {
         await apex.store.saveActivity(undone)
         await request(app)
           .post('/inbox/test')
@@ -498,7 +495,6 @@ describe('inbox', function () {
           .expect(200)
         const result = await apex.store.getActivity(undone.id)
         expect(result).toBeFalsy()
-        done()
       })
       it('succeeds if the undone activity is already deleted', function () {
         return request(app)
@@ -507,7 +503,7 @@ describe('inbox', function () {
           .send(undo)
           .expect(200)
       })
-      it('publishes followers collection updates', async function (done) {
+      it('publishes followers collection updates', async function () {
         const mockedUser = 'https://mocked.com/user/mocked'
         undone.type = 'Follow'
         undone.object = [testUser.id]
@@ -517,26 +513,28 @@ describe('inbox', function () {
         nock('https://mocked.com')
           .get('/user/mocked')
           .reply(200, { id: mockedUser, inbox: 'https://mocked.com/inbox/mocked' })
-        nock('https://mocked.com')
-          .post('/inbox/mocked').reply(200)
-          .on('request', async (req, interceptor, body) => {
-            const sentActivity = JSON.parse(body)
-            // update activity appears in outbox
-            const update = await apex.store.getActivity(sentActivity.id, true)
-            expect(update._meta.collection).toContain(testUser.outbox[0])
-            expect(sentActivity.type).toBe('Update')
-            expect(sentActivity.object.id).toBe(testUser.followers[0])
-            expect(sentActivity.object.totalItems).toBe(0)
-            done()
-          })
-        request(app)
+        const requestValidated = new Promise(resolve => {
+          nock('https://mocked.com')
+            .post('/inbox/mocked').reply(200)
+            .on('request', async (req, interceptor, body) => {
+              const sentActivity = JSON.parse(body)
+              // update activity appears in outbox
+              const update = await apex.store.getActivity(sentActivity.id, true)
+              expect(update._meta.collection).toContain(testUser.outbox[0])
+              expect(sentActivity.type).toBe('Update')
+              expect(sentActivity.object.id).toBe(testUser.followers[0])
+              expect(sentActivity.object.totalItems).toBe(0)
+              resolve()
+            })
+        })
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(undo)
           .expect(200)
-          .end(err => { if (err) done(err) })
+        await requestValidated
       })
-      it('publishes activity collection updates', async function (done) {
+      it('publishes activity collection updates', async function () {
         const mockedUser = 'https://mocked.com/user/mocked'
         const likeable = await apex.buildActivity('Create', testUser.id, [], {
           object: { type: 'Note', content: 'hello' }
@@ -553,21 +551,23 @@ describe('inbox', function () {
         nock('https://mocked.com')
           .get('/user/mocked')
           .reply(200, { id: mockedUser, inbox: 'https://mocked.com/inbox/mocked' })
-        nock('https://mocked.com')
-          .post('/inbox/mocked').reply(200)
-          .on('request', (req, interceptor, body) => {
-            const sentActivity = JSON.parse(body)
-            expect(sentActivity.type).toBe('Update')
-            expect(sentActivity.object.id).toBe(likeable.id)
-            expect(sentActivity.object.likes.totalItems).toBe(0)
-            done()
-          })
-        request(app)
+        const requestValidated = new Promise(resolve => {
+          nock('https://mocked.com')
+            .post('/inbox/mocked').reply(200)
+            .on('request', (req, interceptor, body) => {
+              const sentActivity = JSON.parse(body)
+              expect(sentActivity.type).toBe('Update')
+              expect(sentActivity.object.id).toBe(likeable.id)
+              expect(sentActivity.object.likes.totalItems).toBe(0)
+              resolve()
+            })
+        })
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(undo)
           .expect(200)
-          .end(err => { if (err) done(err) })
+        await requestValidated
       })
     })
     it('fires other activity event', function (done) {
@@ -603,7 +603,7 @@ describe('inbox', function () {
         .set('Content-Type', 'application/activity+json')
         .send(arriveAct)
         .expect(200)
-        .end(err => { if (err) done(err) })
+        .end(err => global.failIfError(err, done))
     })
     it('fires Add event', function (done) {
       const actId = 'https://ignore.com/s/abc123'
@@ -635,7 +635,7 @@ describe('inbox', function () {
         .set('Content-Type', 'application/activity+json')
         .send(addAct)
         .expect(200)
-        .end(err => { if (err) done(err) })
+        .end(err => global.failIfError(err, done))
     })
     it('fires Remove event', function (done) {
       const actId = 'https://ignore.com/s/abc123'
@@ -667,10 +667,10 @@ describe('inbox', function () {
         .set('Content-Type', 'application/activity+json')
         .send(remAct)
         .expect(200)
-        .end(err => { if (err) done(err) })
+        .end(err => global.failIfError(err, done))
     })
     describe('reject', function () {
-      it('fires Reject event', async function (done) {
+      it('fires Reject event', async function () {
         await apex.store.saveActivity(activityNormalized)
         const rejAct = {
           '@context': 'https://www.w3.org/ns/activitystreams',
@@ -680,30 +680,32 @@ describe('inbox', function () {
           actor: 'https://localhost/u/test',
           object: activityNormalized.id
         }
-        app.once('apex-inbox', msg => {
-          expect(msg.actor.id).toBe('https://localhost/u/test')
-          expect(msg.recipient).toEqual(testUser)
-          expect(msg.activity).toEqual({
-            _meta: { collection: ['https://localhost/inbox/test'] },
-            type: 'Reject',
-            id: 'https://localhost/s/a29a6843-9feb-4c74-a7f7-reject',
-            to: ['https://localhost/u/test'],
-            actor: ['https://localhost/u/test'],
-            object: [activityNormalized.id]
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-inbox', msg => {
+            expect(msg.actor.id).toBe('https://localhost/u/test')
+            expect(msg.recipient).toEqual(testUser)
+            expect(msg.activity).toEqual({
+              _meta: { collection: ['https://localhost/inbox/test'] },
+              type: 'Reject',
+              id: 'https://localhost/s/a29a6843-9feb-4c74-a7f7-reject',
+              to: ['https://localhost/u/test'],
+              actor: ['https://localhost/u/test'],
+              object: [activityNormalized.id]
+            })
+            const actRejected = merge(
+              { _meta: { collection: [apex.utils.nameToRejectionsIRI(testUser.preferredUsername)] } },
+              activityNormalized
+            )
+            expect(msg.object).toEqual(actRejected)
+            resolve()
           })
-          const actRejected = merge(
-            { _meta: { collection: [apex.utils.nameToRejectionsIRI(testUser.preferredUsername)] } },
-            activityNormalized
-          )
-          expect(msg.object).toEqual(actRejected)
-          done()
         })
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(rejAct)
           .expect(200)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
       it('updates rejected activity meta', async function () {
         await apex.store.saveActivity(activityNormalized)
@@ -715,16 +717,14 @@ describe('inbox', function () {
           actor: 'https://localhost/u/test',
           object: activityNormalized.id
         }
-        return request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(rejAct)
           .expect(200)
-          .then(async () => {
-            const target = await apex.store.getActivity(activityNormalized.id, true)
-            expect(target._meta).toBeTruthy()
-            expect(target._meta.collection).toContain(apex.utils.nameToRejectionsIRI(testUser.preferredUsername))
-          })
+        const target = await apex.store.getActivity(activityNormalized.id, true)
+        expect(target._meta).toBeTruthy()
+        expect(target._meta.collection).toContain(apex.utils.nameToRejectionsIRI(testUser.preferredUsername))
       })
       it('does not add rejected follow to following', async function () {
         const follow = merge({}, activityNormalized)
@@ -739,16 +739,14 @@ describe('inbox', function () {
           actor: 'https://localhost/u/test',
           object: follow.id
         }
-        return request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(rejAct)
           .expect(200)
-          .then(async () => {
-            const target = await apex.store.getActivity(follow.id, true)
-            expect(target._meta).toBeTruthy()
-            expect(target._meta.collection).not.toContain(testUser.following[0])
-          })
+        const target = await apex.store.getActivity(follow.id, true)
+        expect(target._meta).toBeTruthy()
+        expect(target._meta.collection).not.toContain(testUser.following[0])
       })
       it('undoes prior follow accept', async function () {
         const follow = merge({}, activityNormalized)
@@ -764,16 +762,14 @@ describe('inbox', function () {
           actor: 'https://localhost/u/test',
           object: follow.id
         }
-        return request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(rejAct)
           .expect(200)
-          .then(async () => {
-            const target = await apex.store.getActivity(follow.id, true)
-            expect(target._meta).toBeTruthy()
-            expect(target._meta.collection).not.toContain(testUser.following[0])
-          })
+        const target = await apex.store.getActivity(follow.id, true)
+        expect(target._meta).toBeTruthy()
+        expect(target._meta.collection).not.toContain(testUser.following[0])
       })
     })
     describe('announce', function () {
@@ -793,98 +789,103 @@ describe('inbox', function () {
         // stubs followers collection to avoid resolving objects
         addrSpy = spyOn(apex, 'address').and.callFake(async () => ['https://ignore.com/inbox/ignored'])
       })
-      it('fires announce event', async function (done) {
+      it('fires announce event', async function () {
         await apex.store.saveActivity(targetAct)
-        app.once('apex-inbox', msg => {
-          expect(msg.object.id).toEqual(targetAct.id)
-          done()
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-inbox', msg => {
+            expect(msg.object.id).toEqual(targetAct.id)
+            resolve()
+          })
         })
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(announce)
           .expect(200)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
-      it('adds to shares collection if local', async function (done) {
-        app.once('apex-inbox', async () => {
-          const act = await apex.store.db.collection('streams').findOne({ id: announce.id })
-          expect(act._meta.collection).toEqual([testUser.inbox[0], targetAct.shares[0].id])
-          done()
+      it('adds to shares collection if local', async function () {
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-inbox', async () => {
+            const act = await apex.store.db.collection('streams').findOne({ id: announce.id })
+            expect(act._meta.collection).toEqual([testUser.inbox[0], targetAct.shares[0].id])
+            resolve()
+          })
         })
         await apex.store.saveActivity(targetAct)
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(announce)
           .expect(200)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
-      it('does not add to shares collection if remote', async function (done) {
+      it('does not add to shares collection if remote', async function () {
         targetAct.id = 'https://ignore.com/o/123-abc'
         targetAct.actor = ['https://ignore.com/u/ignored']
         announce.object = targetAct.id
         await apex.store.saveActivity(targetAct)
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(announce)
           .expect(200)
-          .then(() => apex.store.db.collection('streams').findOne({ id: announce.id }))
-          .then(act => {
-            expect(act._meta.collection).toEqual([testUser.inbox[0]])
-            done()
-          })
+        const act = await apex.store.db.collection('streams').findOne({ id: announce.id })
+        expect(act._meta.collection).toEqual([testUser.inbox[0]])
       })
-      it('publishes shared activity update with collection', async function (done) {
-        nock('https://mocked.com').post('/inbox/mocked')
-          .reply(200)
-          .on('request', async (req, interceptor, body) => {
-            // correctly formed activity sent
-            const sentActivity = JSON.parse(body)
-            expect(sentActivity.id).toContain('https://localhost')
-            delete sentActivity.id
-            delete sentActivity.likes
-            delete sentActivity.shares
-            expect(new Date(sentActivity.published).toString()).not.toBe('Invalid Date')
-            delete sentActivity.published
-            delete announce['@context']
-            const updatedAct = await apex.toJSONLD(targetAct)
-            delete updatedAct['@context']
-            updatedAct.shares.totalItems = 1
-            expect(sentActivity).toEqual({
-              '@context': apex.context,
-              type: 'Update',
-              actor: testUser.id,
-              to: 'https://localhost/followers/test',
-              cc: announce.actor,
-              object: updatedAct
+      it('publishes shared activity update with collection', async function () {
+        const requestValidated = new Promise(resolve => {
+          nock('https://mocked.com').post('/inbox/mocked')
+            .reply(200)
+            .on('request', async (req, interceptor, body) => {
+              // correctly formed activity sent
+              const sentActivity = JSON.parse(body)
+              expect(sentActivity.id).toContain('https://localhost')
+              delete sentActivity.id
+              delete sentActivity.likes
+              delete sentActivity.shares
+              expect(new Date(sentActivity.published).toString()).not.toBe('Invalid Date')
+              delete sentActivity.published
+              delete announce['@context']
+              const updatedAct = await apex.toJSONLD(targetAct)
+              delete updatedAct['@context']
+              updatedAct.shares.totalItems = 1
+              expect(sentActivity).toEqual({
+                '@context': apex.context,
+                type: 'Update',
+                actor: testUser.id,
+                to: 'https://localhost/followers/test',
+                cc: announce.actor,
+                object: updatedAct
+              })
+              resolve()
             })
-            done()
-          })
+        })
         // mocks followers collection
         addrSpy.and.callFake(async () => ['https://mocked.com/inbox/mocked'])
         await apex.store.saveActivity(targetAct)
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(announce)
           .expect(200)
-          .end(err => { if (err) done(err) })
+        await requestValidated
       })
-      it('denormalizes announced activity object', async function (done) {
+      it('denormalizes announced activity object', async function () {
         await apex.store.saveActivity(targetAct)
-        app.once('apex-inbox', async msg => {
-          const saved = await apex.store.getActivity(announce.id)
-          expect(saved.object).toEqual([targetAct])
-          done()
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-inbox', async msg => {
+            const saved = await apex.store.getActivity(announce.id)
+            expect(saved.object).toEqual([targetAct])
+            resolve()
+          })
         })
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(announce)
           .expect(200)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
     })
     describe('like', function () {
@@ -904,84 +905,87 @@ describe('inbox', function () {
         // mocks followers collection to avoid resolving objects
         addrSpy = spyOn(apex, 'address').and.callFake(async () => ['https://ignore.com/inbox/ignored'])
       })
-      it('fires like event', async function (done) {
+      it('fires like event', async function () {
         await apex.store.saveActivity(targetAct)
-        app.once('apex-inbox', msg => {
-          expect(msg.object.id).toEqual(targetAct.id)
-          done()
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-inbox', msg => {
+            expect(msg.object.id).toEqual(targetAct.id)
+            resolve()
+          })
         })
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(like)
           .expect(200)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
-      it('adds to likes collection if local', async function (done) {
-        app.once('apex-inbox', async () => {
-          const act = await apex.store.db.collection('streams').findOne({ id: like.id })
-          expect(act._meta.collection).toEqual([testUser.inbox[0], targetAct.likes[0].id])
-          done()
+      it('adds to likes collection if local', async function () {
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-inbox', async () => {
+            const act = await apex.store.db.collection('streams').findOne({ id: like.id })
+            expect(act._meta.collection).toEqual([testUser.inbox[0], targetAct.likes[0].id])
+            resolve()
+          })
         })
         await apex.store.saveActivity(targetAct)
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(like)
           .expect(200)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
-      it('does not add to likes collection if remote', async function (done) {
+      it('does not add to likes collection if remote', async function () {
         targetAct.id = 'https://ignore.com/o/123-abc'
         targetAct.actor = ['https://ignore.com/u/ignored']
         like.object = targetAct.id
         await apex.store.saveActivity(targetAct)
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(like)
           .expect(200)
-          .then(() => apex.store.db.collection('streams').findOne({ id: like.id }))
-          .then(act => {
-            expect(act._meta.collection).toEqual([testUser.inbox[0]])
-            done()
-          })
+        const act = await apex.store.db.collection('streams').findOne({ id: like.id })
+        expect(act._meta.collection).toEqual([testUser.inbox[0]])
       })
-      it('publishes liked object update with collection', async function (done) {
-        nock('https://mocked.com').post('/inbox/mocked')
-          .reply(200)
-          .on('request', async (req, interceptor, body) => {
-            // correctly formed activity sent
-            const sentActivity = JSON.parse(body)
-            expect(sentActivity.id).toContain('https://localhost')
-            delete sentActivity.id
-            delete sentActivity.likes
-            delete sentActivity.shares
-            expect(new Date(sentActivity.published).toString()).not.toBe('Invalid Date')
-            delete sentActivity.published
-            delete like['@context']
-            const updatedAct = await apex.toJSONLD(targetAct)
-            delete updatedAct['@context']
-            updatedAct.likes.totalItems = 1
-            expect(sentActivity).toEqual({
-              '@context': apex.context,
-              type: 'Update',
-              actor: testUser.id,
-              to: 'https://localhost/followers/test',
-              cc: like.actor,
-              object: updatedAct
+      it('publishes liked object update with collection', async function () {
+        const requestValidated = new Promise(resolve => {
+          nock('https://mocked.com').post('/inbox/mocked')
+            .reply(200)
+            .on('request', async (req, interceptor, body) => {
+              // correctly formed activity sent
+              const sentActivity = JSON.parse(body)
+              expect(sentActivity.id).toContain('https://localhost')
+              delete sentActivity.id
+              delete sentActivity.likes
+              delete sentActivity.shares
+              expect(new Date(sentActivity.published).toString()).not.toBe('Invalid Date')
+              delete sentActivity.published
+              delete like['@context']
+              const updatedAct = await apex.toJSONLD(targetAct)
+              delete updatedAct['@context']
+              updatedAct.likes.totalItems = 1
+              expect(sentActivity).toEqual({
+                '@context': apex.context,
+                type: 'Update',
+                actor: testUser.id,
+                to: 'https://localhost/followers/test',
+                cc: like.actor,
+                object: updatedAct
+              })
+              resolve()
             })
-            done()
-          })
+        })
         // mocks followers collection
         addrSpy.and.callFake(async () => ['https://mocked.com/inbox/mocked'])
         await apex.store.saveActivity(targetAct)
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(like)
           .expect(200)
-          .end(err => { if (err) done(err) })
+        await requestValidated
       })
     })
     describe('update', function () {
@@ -998,89 +1002,97 @@ describe('inbox', function () {
           object: merge({}, targetObj)
         }
       })
-      it('fires update event', async function (done) {
+      it('fires update event', async function () {
         await apex.store.saveObject(targetObj)
-        app.once('apex-inbox', msg => {
-          expect(msg.object.id).toEqual(targetObj.id)
-          done()
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-inbox', msg => {
+            expect(msg.object.id).toEqual(targetObj.id)
+            resolve()
+          })
         })
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(update)
           .expect(200)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
-      it('403 if updater is not owner', async function (done) {
+      it('403 if updater is not owner', async function () {
         update.actor = 'https://ignore.com/bob'
         await apex.store.saveObject(targetObj)
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(update)
-          .expect(403, done)
+          .expect(403)
       })
-      it('updates the object in storage', async function (done) {
+      it('updates the object in storage', async function () {
         await apex.store.saveObject(targetObj)
         update.object.content = ['I have been updated']
-        app.once('apex-inbox', async msg => {
-          expect(msg.object.content).toEqual(['I have been updated'])
-          expect((await apex.store.getObject(targetObj.id)).content)
-            .toEqual(['I have been updated'])
-          done()
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-inbox', async msg => {
+            expect(msg.object.content).toEqual(['I have been updated'])
+            expect((await apex.store.getObject(targetObj.id)).content)
+              .toEqual(['I have been updated'])
+            resolve()
+          })
         })
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(update)
           .expect(200)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
-      it('updates the object in streams', async function (done) {
+      it('updates the object in streams', async function () {
         await apex.store.saveActivity(activityNormalized)
         await apex.store.saveObject(targetObj)
         update.object.content = ['I have been updated']
-        app.once('apex-inbox', async msg => {
-          expect(msg.object.content).toEqual(['I have been updated'])
-          const upd = await apex.store.getActivity(activityNormalized.id)
-          expect(upd.object[0].content).toEqual(['I have been updated'])
-          done()
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-inbox', async msg => {
+            expect(msg.object.content).toEqual(['I have been updated'])
+            const upd = await apex.store.getActivity(activityNormalized.id)
+            expect(upd.object[0].content).toEqual(['I have been updated'])
+            resolve()
+          })
         })
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(update)
           .expect(200)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
-      it('processes activity collection updates', async function (done) {
+      it('processes activity collection updates', async function () {
         const orig = merge({}, activityNormalized)
         await apex.store.saveActivity(orig)
         orig.shares[0].totalItems = [5]
         orig.likes[0].totalItems = [3]
         update.object = orig
-        app.once('apex-inbox', async msg => {
-          const inStreams = await apex.store.getActivity(orig.id)
-          expect(inStreams.shares[0]).toEqual({
-            id: orig.shares[0].id,
-            type: 'OrderedCollection',
-            totalItems: [5],
-            first: orig.shares[0].first
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-inbox', async msg => {
+            const inStreams = await apex.store.getActivity(orig.id)
+            expect(inStreams.shares[0]).toEqual({
+              id: orig.shares[0].id,
+              type: 'OrderedCollection',
+              totalItems: [5],
+              first: orig.shares[0].first
+            })
+            expect(inStreams.likes[0]).toEqual({
+              id: orig.likes[0].id,
+              type: 'OrderedCollection',
+              totalItems: [3],
+              first: orig.likes[0].first
+            })
+            resolve()
           })
-          expect(inStreams.likes[0]).toEqual({
-            id: orig.likes[0].id,
-            type: 'OrderedCollection',
-            totalItems: [3],
-            first: orig.likes[0].first
-          })
-          done()
         })
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(update)
           .expect(200)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
     })
     describe('delete', function () {
@@ -1097,72 +1109,78 @@ describe('inbox', function () {
           object: merge({}, targetObj)
         }
       })
-      it('fires delete event', async function (done) {
+      it('fires delete event', async function () {
         await apex.store.saveObject(targetObj)
-        app.once('apex-inbox', msg => {
-          expect(msg.object.id).toEqual(targetObj.id)
-          done()
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-inbox', msg => {
+            expect(msg.object.id).toEqual(targetObj.id)
+            resolve()
+          })
         })
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(del)
           .expect(200)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
-      it('403 if updater is not owner', async function (done) {
+      it('403 if updater is not owner', async function () {
         del.actor = 'https://ignore.com/bob'
         await apex.store.saveObject(targetObj)
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(del)
-          .expect(403, done)
+          .expect(403)
       })
-      it('replaces object in storage with tombstone', async function (done) {
+      it('replaces object in storage with tombstone', async function () {
         await apex.store.saveObject(targetObj)
-        app.once('apex-inbox', async msg => {
-          expect(msg.object.content).toEqual(['Say, did you finish reading that book I lent you?'])
-          const tomb = await apex.store.getObject(targetObj.id)
-          expect(new Date(tomb.deleted).toString()).not.toBe('Invalid Date')
-          delete tomb.deleted
-          delete tomb.updated
-          delete tomb.published
-          expect(tomb).toEqual({
-            id: targetObj.id,
-            type: 'Tombstone'
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-inbox', async msg => {
+            expect(msg.object.content).toEqual(['Say, did you finish reading that book I lent you?'])
+            const tomb = await apex.store.getObject(targetObj.id)
+            expect(new Date(tomb.deleted).toString()).not.toBe('Invalid Date')
+            delete tomb.deleted
+            delete tomb.updated
+            delete tomb.published
+            expect(tomb).toEqual({
+              id: targetObj.id,
+              type: 'Tombstone'
+            })
+            resolve()
           })
-          done()
         })
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(del)
           .expect(200)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
-      it('replaces object in streams with tombstone', async function (done) {
+      it('replaces object in streams with tombstone', async function () {
         await apex.store.saveObject(targetObj)
         await apex.store.saveActivity(activityNormalized)
-        app.once('apex-inbox', async msg => {
-          expect(msg.object.content).toEqual(['Say, did you finish reading that book I lent you?'])
-          const tomb = (await apex.store.getActivity(activityNormalized.id)).object[0]
-          expect(new Date(tomb.deleted).toString()).not.toBe('Invalid Date')
-          delete tomb.deleted
-          delete tomb.updated
-          delete tomb.published
-          expect(tomb).toEqual({
-            id: targetObj.id,
-            type: 'Tombstone'
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-inbox', async msg => {
+            expect(msg.object.content).toEqual(['Say, did you finish reading that book I lent you?'])
+            const tomb = (await apex.store.getActivity(activityNormalized.id)).object[0]
+            expect(new Date(tomb.deleted).toString()).not.toBe('Invalid Date')
+            delete tomb.deleted
+            delete tomb.updated
+            delete tomb.published
+            expect(tomb).toEqual({
+              id: targetObj.id,
+              type: 'Tombstone'
+            })
+            resolve()
           })
-          done()
         })
-        request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(del)
           .expect(200)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
     })
     describe('asynchronicity', function () {
@@ -1184,7 +1202,7 @@ describe('inbox', function () {
         const final = await apex.store.getActivity(activity.id, true)
         expect(final._meta.collection.sort()).toEqual(users.map(u => u.inbox[0]))
       })
-      it('sends collection update when owner is not first recipient', async function (done) {
+      it('sends collection update when owner is not first recipient', async function () {
         await apex.store.saveActivity(activityNormalized)
         const u2 = await apex.createActor('test2', 'Test 2')
         await apex.store.saveObject(u2)
@@ -1197,27 +1215,30 @@ describe('inbox', function () {
         nock('https://mocked.com')
           .get('/u/mocked')
           .reply(200, { id: 'https://mocked.com/u/mocked', inbox: 'https://mocked.com/inbox/mocked' })
-        nock('https://mocked.com')
-          .post('/inbox/mocked')
-          .reply(200)
-          .on('request', (req, interceptor, body) => {
-            body = JSON.parse(body)
-            expect(body.type).toBe('Update')
-            expect(body.actor).toBe(testUser.id)
-            expect(body.object.id).toBe(activity.id)
-            expect(body.object.likes.totalItems).toBe(1)
-            done()
-          })
+        const requestValidated = new Promise(resolve => {
+          nock('https://mocked.com')
+            .post('/inbox/mocked')
+            .reply(200)
+            .on('request', (req, interceptor, body) => {
+              body = JSON.parse(body)
+              expect(body.type).toBe('Update')
+              expect(body.actor).toBe(testUser.id)
+              expect(body.object.id).toBe(activity.id)
+              expect(body.object.likes.totalItems).toBe(1)
+              resolve()
+            })
+        })
         await request(app)
           .post(u2.inbox[0].replace('https://localhost', ''))
           .set('Content-Type', 'application/activity+json')
           .send(like)
           .expect(200)
-        return request(app)
+        await request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(like)
           .expect(200)
+        await requestValidated
       })
     })
     describe('signature verification', function () {
@@ -1319,8 +1340,9 @@ describe('inbox', function () {
         .set('Accept', 'application/activity+json')
         .expect(200)
         .end((err, res) => {
+          if (err) done.fail(err)
           expect(res.body).toEqual(inboxCollection)
-          done(err)
+          done()
         })
     })
     it('returns page as ordered collection page', (done) => {
@@ -1363,8 +1385,9 @@ describe('inbox', function () {
         .set('Accept', 'application/activity+json')
         .expect(200)
         .end((err, res) => {
+          if (err) done.fail(err)
           expect(res.body).toEqual(inboxCollectionPage)
-          done(err)
+          done()
         })
     })
     it('includes non-public posts when authorized', (done) => {
@@ -1373,6 +1396,7 @@ describe('inbox', function () {
         .set('Accept', 'application/activity+json')
         .expect(200)
         .end((err, res) => {
+          if (err) done.fail(err)
           expect(res.body.orderedItems.length).toBe(4)
           expect(res.body.orderedItems[0]).toEqual({
             type: 'Create',
@@ -1399,10 +1423,10 @@ describe('inbox', function () {
               first: 'https://localhost/s/a29a6843-9feb-4c74-a7f7-081b9c9201d3/likes?page=true'
             }
           })
-          done(err)
+          done()
         })
     })
-    it('filters blocked actors', async function (done) {
+    it('filters blocked actors', async function () {
       const meta = { collection: ['https://localhost/inbox/test'] }
       const blocked = merge.all([
         {},
@@ -1448,14 +1472,11 @@ describe('inbox', function () {
           }
         }))
       }
-      request(app)
+      const res = await request(app)
         .get('/inbox/test?page=true')
         .set('Accept', 'application/activity+json')
         .expect(200)
-        .end((err, res) => {
-          expect(res.body).toEqual(inboxCollection)
-          done(err)
-        })
+      expect(res.body).toEqual(inboxCollection)
     })
   })
 })

--- a/spec/functional/nodeinfo.spec.js
+++ b/spec/functional/nodeinfo.spec.js
@@ -35,7 +35,7 @@ describe('nodeinfo', function () {
               href: 'https://localhost/nodeinfo/2.0'
             }
           ]
-        }, done)
+        }, err => global.failOrDone(err, done))
     })
   })
   describe('document get', function () {
@@ -55,12 +55,12 @@ describe('nodeinfo', function () {
           metadata: {
             foo: 'bar'
           }
-        }, done)
+        }, err => global.failOrDone(err, done))
     })
     it('404s on 1.x nodeinfo requests', function (done) {
       request(app)
         .get('/nodeinfo/1.0')
-        .expect(404, done)
+        .expect(404, err => global.failOrDone(err, done))
     })
   })
 })

--- a/spec/functional/outbox.spec.js
+++ b/spec/functional/outbox.spec.js
@@ -97,7 +97,7 @@ describe('outbox', function () {
       request(app)
         .post('/authorized/outbox/test')
         .send({})
-        .expect(404, done)
+        .expect(404, err => global.failOrDone(err, done))
     })
     // validators activity
     it('errors invalid activities', function (done) {
@@ -105,7 +105,7 @@ describe('outbox', function () {
         .post('/authorized/outbox/test')
         .set('Content-Type', 'application/activity+json')
         .send({ actor: 'bob', '@context': 'https://www.w3.org/ns/activitystreams' })
-        .expect(400, 'Invalid activity', done)
+        .expect(400, 'Invalid activity', err => global.failOrDone(err, done))
     })
     it('rejects unauthorized requests', function () {
       return request(app)
@@ -120,7 +120,7 @@ describe('outbox', function () {
         .post('/authorized/outbox/noone')
         .set('Content-Type', 'application/activity+json')
         .send(activity)
-        .expect(404, '\'noone\' not found on this instance', done)
+        .expect(404, '\'noone\' not found on this instance', err => global.failOrDone(err, done))
     })
     it('responds 201 with Location header', function () {
       return request(app)
@@ -230,10 +230,10 @@ describe('outbox', function () {
         .send(act)
         .expect(201)
         .end(function (err) {
-          if (err) throw err
+          if (err) done.fail(err)
         })
     })
-    it('does not deliver to blocked actors', async function (done) {
+    it('does not deliver to blocked actors', async function () {
       const deliverSpy = spyOn(apex, 'queueForDelivery')
       const act = merge({}, activity)
       act.to = act.object.to = ['https://localhost/u/blocked']
@@ -247,18 +247,18 @@ describe('outbox', function () {
         inbox: 'https://localhost/u/blocked/inbox'
       })
       await apex.store.saveActivity(block)
-      app.once('apex-outbox', msg => {
-        expect(deliverSpy).not.toHaveBeenCalled()
-        done()
+      const callbackReceived = new Promise(resolve => {
+        app.once('apex-outbox', msg => {
+          expect(deliverSpy).not.toHaveBeenCalled()
+          resolve()
+        })
       })
-      request(app)
+      await request(app)
         .post('/authorized/outbox/test')
         .set('Content-Type', 'application/activity+json')
         .send(act)
         .expect(201)
-        .end(function (err) {
-          if (err) throw err
-        })
+      await callbackReceived
     })
     // activity side effects
     it('fires create event', function (done) {
@@ -274,7 +274,7 @@ describe('outbox', function () {
         .set('Content-Type', 'application/activity+json')
         .send(activity)
         .expect(201)
-        .end(err => { if (err) done(err) })
+        .end(err => { if (err) done.fail(err) })
     })
     describe('undo', function () {
       let undo
@@ -290,26 +290,28 @@ describe('outbox', function () {
           object: undone.id
         }
       })
-      it('fires undo event', async function (done) {
+      it('fires undo event', async function () {
         await apex.store.saveActivity(undone)
-        app.once('apex-outbox', () => {
-          done()
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-outbox', () => {
+            resolve()
+          })
         })
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(undo)
           .expect(201)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
-      it('rejects undo with owner mismatch', async function (done) {
+      it('rejects undo with owner mismatch', async function () {
         undone.actor = ['https://ignore.com/bob']
         await apex.store.saveActivity(undone)
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(undo)
-          .expect(403, done)
+          .expect(403)
       })
       it('removes undone activity', async function () {
         await apex.store.saveActivity(undone)
@@ -321,7 +323,7 @@ describe('outbox', function () {
         const result = await apex.store.getActivity(undone.id)
         expect(result).toBeFalsy()
       })
-      it('publishes related collection updates', async function (done) {
+      it('publishes related collection updates', async function () {
         const mockedUser = 'https://mocked.com/user/mocked'
         undone.type = 'Like'
         undone.object = [activityNormalized.object[0].id]
@@ -332,26 +334,28 @@ describe('outbox', function () {
         nock('https://mocked.com')
           .get('/user/mocked')
           .reply(200, { id: mockedUser, inbox: 'https://mocked.com/inbox/mocked' })
-        nock('https://mocked.com')
-          .post('/inbox/mocked').reply(200)
-          .on('request', async (req, interceptor, body) => {
-            const sentActivity = JSON.parse(body)
-            // update activity appears in outbox
-            const update = await apex.store.getActivity(sentActivity.id, true)
-            expect(update._meta.collection).toContain(testUser.outbox[0])
-            expect(sentActivity.type).toBe('Update')
-            expect(sentActivity.object.id).toBe(testUser.liked[0])
-            expect(sentActivity.object.totalItems).toBe(0)
-            done()
-          })
-        request(app)
+        const requestValidated = new Promise(resolve => {
+          nock('https://mocked.com')
+            .post('/inbox/mocked').reply(200)
+            .on('request', async (req, interceptor, body) => {
+              const sentActivity = JSON.parse(body)
+              // update activity appears in outbox
+              const update = await apex.store.getActivity(sentActivity.id, true)
+              expect(update._meta.collection).toContain(testUser.outbox[0])
+              expect(sentActivity.type).toBe('Update')
+              expect(sentActivity.object.id).toBe(testUser.liked[0])
+              expect(sentActivity.object.totalItems).toBe(0)
+              resolve()
+            })
+        })
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(undo)
           .expect(201)
-          .end(err => { if (err) done(err) })
+        await requestValidated
       })
-      it('unfollows if object is actor', async function (done) {
+      it('unfollows if object is actor', async function () {
         const mockedUser = 'https://mocked.com/user/mocked'
         undone.type = 'Follow'
         undone.object = [mockedUser]
@@ -379,22 +383,24 @@ describe('outbox', function () {
         nock('https://mocked.com')
           .post('/inbox/mocked').reply(200)
 
-        app.once('apex-outbox', async () => {
-          // user id is replaced with related follow activity
-          expect(sentActivity.object.id).toBe(undone.id)
-          // follows updated
-          expect((await apex.getFollowing(testUser, Infinity, true)).orderedItems)
-            .toEqual([])
-          done()
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-outbox', async () => {
+            // user id is replaced with related follow activity
+            expect(sentActivity.object.id).toBe(undone.id)
+            // follows updated
+            expect((await apex.getFollowing(testUser, Infinity, true)).orderedItems)
+              .toEqual([])
+            resolve()
+          })
         })
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(undo)
           .expect(201)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
-      it('unblocks if object is blocked actor', async function (done) {
+      it('unblocks if object is blocked actor', async function () {
         const mockedUser = 'https://mocked.com/user/mocked'
         undone.type = 'Block'
         undone.object = [mockedUser]
@@ -409,18 +415,20 @@ describe('outbox', function () {
           object: mockedUser,
           to: mockedUser
         }
-        app.once('apex-outbox', async () => {
-          // blocklist updated
-          expect((await apex.getBlocked(testUser, Infinity, true)).orderedItems)
-            .toEqual([])
-          done()
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-outbox', async () => {
+            // blocklist updated
+            expect((await apex.getBlocked(testUser, Infinity, true)).orderedItems)
+              .toEqual([])
+            resolve()
+          })
         })
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(undo)
           .expect(201)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
     })
     describe('update', function () {
@@ -465,37 +473,37 @@ describe('outbox', function () {
         expect(activities[0].object[0]).toEqual(expectedObj)
         expect(activities[1].object[0]).toEqual(expectedObj)
       })
-      it('adds updated object recipients to audience')
-      it('federates whole updated object', async function (done) {
+      // it('adds updated object recipients to audience')
+      it('federates whole updated object', async function () {
         update.to = ['https://mocked.com/user/mocked']
         update.object[0].to = ['https://mocked.com/user/mocked']
         nock('https://mocked.com')
           .get('/user/mocked')
           .reply(200, { id: 'https://mocked.com/user/mocked', inbox: 'https://mocked.com/inbox/mocked' })
-        nock('https://mocked.com').post('/inbox/mocked')
-          .reply(200)
-          .on('request', (req, interceptor, body) => {
-            const sentActivity = JSON.parse(body)
-            expect(sentActivity.object).toEqual({
-              id: sourceObj.id,
-              type: 'Note',
-              attributedTo: 'https://localhost/u/test',
-              to: 'https://mocked.com/user/mocked',
-              audience: 'as:Public',
-              content: 'updated'
+        const requestValidated = new Promise(resolve => {
+          nock('https://mocked.com').post('/inbox/mocked')
+            .reply(200)
+            .on('request', (req, interceptor, body) => {
+              const sentActivity = JSON.parse(body)
+              expect(sentActivity.object).toEqual({
+                id: sourceObj.id,
+                type: 'Note',
+                attributedTo: 'https://localhost/u/test',
+                to: 'https://mocked.com/user/mocked',
+                audience: 'as:Public',
+                content: 'updated'
+              })
+              resolve()
             })
-            done()
-          })
-        request(app)
+        })
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(update)
           .expect(201)
-          .end(function (err) {
-            if (err) throw err
-          })
+        await requestValidated
       })
-      it('does not leak private keys', async function (done) {
+      it('does not leak private keys', async function () {
         update.to = ['https://mocked.com/user/mocked']
         update.object = [{
           id: testUser.id,
@@ -504,27 +512,27 @@ describe('outbox', function () {
         nock('https://mocked.com')
           .get('/user/mocked')
           .reply(200, { id: 'https://mocked.com/user/mocked', inbox: 'https://mocked.com/inbox/mocked' })
-        nock('https://mocked.com').post('/inbox/mocked')
-          .reply(200)
-          .on('request', async (req, interceptor, body) => {
-            const sentActivity = JSON.parse(body)
-            const standard = await apex.toJSONLD(merge({}, testUser))
-            delete standard._meta
-            delete standard._local
-            delete standard._id
-            delete standard['@context']
-            standard.name = 'New display name'
-            expect(sentActivity.object).toEqual(standard)
-            done()
-          })
-        request(app)
+        const requestValidated = new Promise(resolve => {
+          nock('https://mocked.com').post('/inbox/mocked')
+            .reply(200)
+            .on('request', async (req, interceptor, body) => {
+              const sentActivity = JSON.parse(body)
+              const standard = await apex.toJSONLD(merge({}, testUser))
+              delete standard._meta
+              delete standard._local
+              delete standard._id
+              delete standard['@context']
+              standard.name = 'New display name'
+              expect(sentActivity.object).toEqual(standard)
+              resolve()
+            })
+        })
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(update)
           .expect(201)
-          .end(function (err) {
-            if (err) throw err
-          })
+        await requestValidated
       })
     })
     describe('accept', function () {
@@ -541,89 +549,95 @@ describe('outbox', function () {
         accept.object = follow.id
         accept.type = 'Accept'
       })
-      it('fires accept event', async function (done) {
+      it('fires accept event', async function () {
         await apex.store.saveActivity(follow)
-        app.once('apex-outbox', msg => {
-          expect(msg.actor).toEqual(testUser)
-          const exp = merge({ _meta: { collection: ['https://localhost/outbox/test'] } }, activityNormalized)
-          exp.type = 'Accept'
-          exp.object = [follow.id]
-          expect(global.stripIds(msg.activity)).toEqual(exp)
-          follow._meta.collection.push(testUser.followers[0])
-          expect(msg.object).toEqual(follow)
-          done()
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-outbox', msg => {
+            expect(msg.actor).toEqual(testUser)
+            const exp = merge({ _meta: { collection: ['https://localhost/outbox/test'] } }, activityNormalized)
+            exp.type = 'Accept'
+            exp.object = [follow.id]
+            expect(global.stripIds(msg.activity)).toEqual(exp)
+            follow._meta.collection.push(testUser.followers[0])
+            expect(msg.object).toEqual(follow)
+            resolve()
+          })
         })
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(accept)
           .expect(201)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
-      it('handles accept of follow without to field', async function (done) {
+      it('handles accept of follow without to field', async function () {
         delete follow.to
         await apex.store.saveActivity(follow)
-        app.once('apex-outbox', msg => {
-          expect(msg.actor).toEqual(testUser)
-          const exp = merge({ _meta: { collection: ['https://localhost/outbox/test'] } }, activityNormalized)
-          exp.type = 'Accept'
-          exp.object = [follow.id]
-          expect(global.stripIds(msg.activity)).toEqual(exp)
-          follow._meta.collection.push(testUser.followers[0])
-          expect(msg.object).toEqual(follow)
-          done()
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-outbox', msg => {
+            expect(msg.actor).toEqual(testUser)
+            const exp = merge({ _meta: { collection: ['https://localhost/outbox/test'] } }, activityNormalized)
+            exp.type = 'Accept'
+            exp.object = [follow.id]
+            expect(global.stripIds(msg.activity)).toEqual(exp)
+            follow._meta.collection.push(testUser.followers[0])
+            expect(msg.object).toEqual(follow)
+            resolve()
+          })
         })
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(accept)
           .expect(201)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
-      it('publishes collection update', async function (done) {
+      it('publishes collection update', async function () {
         const mockedUser = 'https://mocked.com/user/mocked'
         nock('https://mocked.com')
           .get('/user/mocked')
           .reply(200, { id: mockedUser, type: 'Actor', inbox: 'https://mocked.com/inbox/mocked' })
-        nock('https://mocked.com')
-          .post('/inbox/mocked').reply(200) // accept activity delivery
-          .post('/inbox/mocked').reply(200)
-          .on('request', async (req, interceptor, body) => {
-            const sentActivity = JSON.parse(body)
-            if (sentActivity.type === 'Accept') return
-            expect(sentActivity.id).toContain('https://localhost')
-            // update activity appears in outbox
-            const update = await apex.store.getActivity(sentActivity.id, true)
-            expect(update._meta.collection).toContain(testUser.outbox[0])
-            // correctly formed activity sent
-            delete sentActivity.id
-            delete sentActivity.likes
-            delete sentActivity.shares
-            expect(new Date(sentActivity.published).toString()).not.toBe('Invalid Date')
-            delete sentActivity.published
-            expect(sentActivity).toEqual({
-              '@context': apex.context,
-              type: 'Update',
-              actor: testUser.id,
-              to: testUser.followers[0],
-              object: {
-                id: testUser.followers[0],
-                type: 'OrderedCollection',
-                totalItems: 1,
-                first: 'https://localhost/followers/test?page=true'
-              }
+        const requestValidated = new Promise(resolve => {
+          nock('https://mocked.com')
+            .post('/inbox/mocked').reply(200) // accept activity delivery
+            .post('/inbox/mocked').reply(200)
+            .on('request', async (req, interceptor, body) => {
+              const sentActivity = JSON.parse(body)
+              if (sentActivity.type === 'Accept') return
+              expect(sentActivity.id).toContain('https://localhost')
+              // update activity appears in outbox
+              const update = await apex.store.getActivity(sentActivity.id, true)
+              expect(update._meta.collection).toContain(testUser.outbox[0])
+              // correctly formed activity sent
+              delete sentActivity.id
+              delete sentActivity.likes
+              delete sentActivity.shares
+              expect(new Date(sentActivity.published).toString()).not.toBe('Invalid Date')
+              delete sentActivity.published
+              expect(sentActivity).toEqual({
+                '@context': apex.context,
+                type: 'Update',
+                actor: testUser.id,
+                to: testUser.followers[0],
+                object: {
+                  id: testUser.followers[0],
+                  type: 'OrderedCollection',
+                  totalItems: 1,
+                  first: 'https://localhost/followers/test?page=true'
+                }
+              })
+              resolve()
             })
-            done()
-          })
+        })
         follow.actor = [mockedUser]
         accept.to = mockedUser
         await apex.store.saveActivity(follow)
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(accept)
           .expect(201)
-          .end(err => { if (err) done(err) })
+        await requestValidated
       })
     })
     describe('reject', function () {
@@ -642,54 +656,58 @@ describe('outbox', function () {
         reject.type = 'Reject'
         rejected = apex.utils.nameToRejectedIRI(testUser.preferredUsername)
       })
-      it('fires reject event', async function (done) {
+      it('fires reject event', async function () {
         await apex.store.saveActivity(follow)
-        app.once('apex-outbox', msg => {
-          expect(msg.actor).toEqual(testUser)
-          const exp = merge({ _meta: { collection: testUser.outbox } }, activityNormalized)
-          exp.type = 'Reject'
-          exp.object = [follow.id]
-          expect(global.stripIds(msg.activity)).toEqual(exp)
-          // removed from followers
-          follow._meta.collection = [testUser.inbox[0], rejected]
-          expect(msg.object).toEqual(follow)
-          done()
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-outbox', msg => {
+            expect(msg.actor).toEqual(testUser)
+            const exp = merge({ _meta: { collection: testUser.outbox } }, activityNormalized)
+            exp.type = 'Reject'
+            exp.object = [follow.id]
+            expect(global.stripIds(msg.activity)).toEqual(exp)
+            // removed from followers
+            follow._meta.collection = [testUser.inbox[0], rejected]
+            expect(msg.object).toEqual(follow)
+            resolve()
+          })
         })
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(reject)
           .expect(201)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
-      it('publishes collection update', async function (done) {
+      it('publishes collection update', async function () {
         const mockedUser = 'https://mocked.com/user/mocked'
-        nock('https://mocked.com')
-          .post('/inbox/mocked').reply(200)
-          .on('request', (req, interceptor, body) => {
-            const sentActivity = JSON.parse(body)
-            // ignore initial activity
-            if (sentActivity.type === 'Reject') return
-            expect(sentActivity.id).toContain('https://localhost')
-            delete sentActivity.id
-            delete sentActivity.likes
-            delete sentActivity.shares
-            expect(new Date(sentActivity.published).toString()).not.toBe('Invalid Date')
-            delete sentActivity.published
-            expect(sentActivity).toEqual({
-              '@context': apex.context,
-              type: 'Update',
-              actor: testUser.id,
-              to: testUser.followers[0],
-              object: {
-                id: testUser.followers[0],
-                type: 'OrderedCollection',
-                totalItems: 1,
-                first: 'https://localhost/followers/test?page=true'
-              }
+        const requestValidated = new Promise(resolve => {
+          nock('https://mocked.com')
+            .post('/inbox/mocked').reply(200)
+            .on('request', (req, interceptor, body) => {
+              const sentActivity = JSON.parse(body)
+              // ignore initial activity
+              if (sentActivity.type === 'Reject') return
+              expect(sentActivity.id).toContain('https://localhost')
+              delete sentActivity.id
+              delete sentActivity.likes
+              delete sentActivity.shares
+              expect(new Date(sentActivity.published).toString()).not.toBe('Invalid Date')
+              delete sentActivity.published
+              expect(sentActivity).toEqual({
+                '@context': apex.context,
+                type: 'Update',
+                actor: testUser.id,
+                to: testUser.followers[0],
+                object: {
+                  id: testUser.followers[0],
+                  type: 'OrderedCollection',
+                  totalItems: 1,
+                  first: 'https://localhost/followers/test?page=true'
+                }
+              })
+              resolve()
             })
-            done()
-          })
+        })
         await apex.store.saveObject({ id: mockedUser, type: 'Actor', inbox: ['https://mocked.com/inbox/mocked'] })
         await apex.store.saveActivity(follow)
         // actor needs one follower remaining to deliver collection udpate
@@ -697,14 +715,14 @@ describe('outbox', function () {
         otherFollow.id = apex.utils.activityIdToIRI()
         otherFollow.actor = [mockedUser]
         await apex.store.saveActivity(otherFollow)
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(reject)
           .expect(201)
-          .end(err => { if (err) done(err) })
+        await requestValidated
       })
-      it('rejects prior follow if object is actor', async function (done) {
+      it('rejects prior follow if object is actor', async function () {
         const mockedUser = 'https://mocked.com/user/mocked'
         const mockedUserObj = { id: mockedUser, type: 'Actor', inbox: ['https://mocked.com/inbox/mocked'] }
         let sentActivity
@@ -720,20 +738,22 @@ describe('outbox', function () {
         await apex.store.saveActivity(follow)
         reject.object = mockedUser
         reject.to = mockedUser
-        app.once('apex-outbox', async () => {
-          expect(sentActivity.object.id).toBe(follow.id)
-          expect((await apex.getFollowers(testUser, Infinity, true)).orderedItems)
-            .toEqual([])
-          done()
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-outbox', async () => {
+            expect(sentActivity.object.id).toBe(follow.id)
+            expect((await apex.getFollowers(testUser, Infinity, true)).orderedItems)
+              .toEqual([])
+            resolve()
+          })
         })
         expect((await apex.getFollowers(testUser, Infinity, true)).orderedItems)
           .toEqual([mockedUserObj])
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(reject)
           .expect(201)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
     })
     describe('delete', function () {
@@ -746,86 +766,92 @@ describe('outbox', function () {
         deleteAct.type = 'Delete'
         deleteAct.object = 'https://localhost/o/2349-ssdfds-34tdgf'
       })
-      it('fires delete event', async function (done) {
+      it('fires delete event', async function () {
         await apex.store.saveObject(toDelete)
-        app.once('apex-outbox', function (msg) {
-          expect(msg.actor).toEqual(testUser)
-          expect(global.stripIds(msg.activity)).toEqual({
-            _meta: { collection: ['https://localhost/outbox/test'] },
-            type: 'Delete',
-            actor: ['https://localhost/u/test'],
-            object: ['https://localhost/o/2349-ssdfds-34tdgf'],
-            to: [
-              'https://ignore.com/u/ignored'
-            ],
-            audience: ['as:Public'],
-            likes: [{ totalItems: [0], type: 'OrderedCollection' }],
-            shares: [{ totalItems: [0], type: 'OrderedCollection' }]
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-outbox', function (msg) {
+            expect(msg.actor).toEqual(testUser)
+            expect(global.stripIds(msg.activity)).toEqual({
+              _meta: { collection: ['https://localhost/outbox/test'] },
+              type: 'Delete',
+              actor: ['https://localhost/u/test'],
+              object: ['https://localhost/o/2349-ssdfds-34tdgf'],
+              to: [
+                'https://ignore.com/u/ignored'
+              ],
+              audience: ['as:Public'],
+              likes: [{ totalItems: [0], type: 'OrderedCollection' }],
+              shares: [{ totalItems: [0], type: 'OrderedCollection' }]
+            })
+            expect(msg.object).toEqual(toDelete)
+            resolve()
           })
-          expect(msg.object).toEqual(toDelete)
-          done()
         })
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(deleteAct)
           .expect(201)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
-      it('rejects if actor not owner', async function (done) {
+      it('rejects if actor not owner', async function () {
         toDelete.attributedTo = ['https://localhost/u/sally']
         await apex.store.saveObject(toDelete)
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(deleteAct)
-          .expect(403, done)
+          .expect(403)
       })
-      it('replaces object in store with tombstone', async function (done) {
+      it('replaces object in store with tombstone', async function () {
         await apex.store.saveObject(toDelete)
-        app.once('apex-outbox', async function () {
-          const tomb = await apex.store.getObject(toDelete.id)
-          expect(new Date(tomb.deleted).toString()).not.toBe('Invalid Date')
-          delete tomb.deleted
-          delete tomb.published
-          delete tomb.updated
-          expect(tomb).toEqual({
-            id: toDelete.id,
-            type: 'Tombstone'
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-outbox', async function () {
+            const tomb = await apex.store.getObject(toDelete.id)
+            expect(new Date(tomb.deleted).toString()).not.toBe('Invalid Date')
+            delete tomb.deleted
+            delete tomb.published
+            delete tomb.updated
+            expect(tomb).toEqual({
+              id: toDelete.id,
+              type: 'Tombstone'
+            })
+            resolve()
           })
-          done()
         })
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(deleteAct)
           .expect(201)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
-      it('replaces object in streams with tombstone', async function (done) {
+      it('replaces object in streams with tombstone', async function () {
         await apex.store.saveObject(toDelete)
         const original = merge({}, activityNormalized)
         original.id = apex.utils.activityIdToIRI()
         original.object[0].id = toDelete.id
         await apex.store.saveActivity(original)
-        app.once('apex-outbox', async () => {
-          const tomb = (await apex.store.getActivity(original.id)).object[0]
-          expect(new Date(tomb.deleted).toString()).not.toBe('Invalid Date')
-          delete tomb.deleted
-          delete tomb.updated
-          delete tomb.published
-          expect(tomb).toEqual({
-            id: toDelete.id,
-            type: 'Tombstone'
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-outbox', async () => {
+            const tomb = (await apex.store.getActivity(original.id)).object[0]
+            expect(new Date(tomb.deleted).toString()).not.toBe('Invalid Date')
+            delete tomb.deleted
+            delete tomb.updated
+            delete tomb.published
+            expect(tomb).toEqual({
+              id: toDelete.id,
+              type: 'Tombstone'
+            })
+            resolve()
           })
-          done()
         })
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(deleteAct)
           .expect(201)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
     })
     describe('announce', function () {
@@ -838,20 +864,22 @@ describe('outbox', function () {
         announce.type = 'Announce'
         announce.object = announceable.id
       })
-      it('does not denormalize object in delivered activity', async function (done) {
+      it('does not denormalize object in delivered activity', async function () {
         await apex.store.saveActivity(announceable)
-        spyOn(apex, 'publishActivity')
-        app.once('apex-outbox', function () {
-          expect(apex.publishActivity.calls.argsFor(0)[1].object)
-            .toEqual([announceable.id])
-          done()
+        const callbackReceived = new Promise(resolve => {
+          spyOn(apex, 'publishActivity')
+          app.once('apex-outbox', function () {
+            expect(apex.publishActivity.calls.argsFor(0)[1].object)
+              .toEqual([announceable.id])
+            resolve()
+          })
         })
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(announce)
           .expect(201)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
     })
     describe('like', function () {
@@ -864,45 +892,49 @@ describe('outbox', function () {
         like.type = 'Like'
         like.object = likeable.id
       })
-      it('fires like event', async function (done) {
+      it('fires like event', async function () {
         await apex.store.saveActivity(likeable)
-        app.once('apex-outbox', function (msg) {
-          expect(msg.actor).toEqual(testUser)
-          delete msg.activity.id
-          delete msg.activity.likes
-          delete msg.activity.shares
-          delete msg.activity.published
-          expect(msg.activity).toEqual({
-            _meta: { collection: [testUser.outbox[0], testUser.liked[0]] },
-            type: 'Like',
-            actor: ['https://localhost/u/test'],
-            object: [likeable],
-            to: ['https://ignore.com/u/ignored'],
-            audience: ['as:Public']
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-outbox', function (msg) {
+            expect(msg.actor).toEqual(testUser)
+            delete msg.activity.id
+            delete msg.activity.likes
+            delete msg.activity.shares
+            delete msg.activity.published
+            expect(msg.activity).toEqual({
+              _meta: { collection: [testUser.outbox[0], testUser.liked[0]] },
+              type: 'Like',
+              actor: ['https://localhost/u/test'],
+              object: [likeable],
+              to: ['https://ignore.com/u/ignored'],
+              audience: ['as:Public']
+            })
+            expect(msg.object).toEqual(likeable)
+            resolve()
           })
-          expect(msg.object).toEqual(likeable)
-          done()
         })
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(like)
           .expect(201)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
-      it('adds to liked collection', async function (done) {
+      it('adds to liked collection', async function () {
         await apex.store.saveActivity(likeable)
-        app.once('apex-outbox', async function (msg) {
-          const liked = await apex.getLiked(testUser, Infinity, true)
-          expect(liked.orderedItems).toEqual([likeable])
-          done()
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-outbox', async function (msg) {
+            const liked = await apex.getLiked(testUser, Infinity, true)
+            expect(liked.orderedItems).toEqual([likeable])
+            resolve()
+          })
         })
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(like)
           .expect(201)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
       it('rejects if no object', function (done) {
         delete like.object
@@ -910,47 +942,49 @@ describe('outbox', function () {
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(like)
-          .expect(400, done)
+          .expect(400, err => global.failOrDone(err, done))
       })
-      it('publishes collection update', async function (done) {
+      it('publishes collection update', async function () {
         const mockedUser = 'https://mocked.com/user/mocked'
-        nock('https://mocked.com')
-          .post('/inbox/mocked').reply(200) // like activity delivery
-          .post('/inbox/mocked').reply(200)
-          .on('request', (req, interceptor, body) => {
-            // correctly formed activity sent
-            const sentActivity = JSON.parse(body)
-            if (sentActivity.type === 'Like') return
-            expect(sentActivity.id).toContain('https://localhost')
-            delete sentActivity.id
-            delete sentActivity.likes
-            delete sentActivity.shares
-            expect(new Date(sentActivity.published).toString()).not.toBe('Invalid Date')
-            delete sentActivity.published
-            expect(sentActivity).toEqual({
-              '@context': apex.context,
-              type: 'Update',
-              actor: testUser.id,
-              to: testUser.followers[0],
-              object: {
-                id: testUser.liked[0],
-                type: 'OrderedCollection',
-                totalItems: 1,
-                first: 'https://localhost/liked/test?page=true'
-              }
+        const requestValidated = new Promise(resolve => {
+          nock('https://mocked.com')
+            .post('/inbox/mocked').reply(200) // like activity delivery
+            .post('/inbox/mocked').reply(200)
+            .on('request', (req, interceptor, body) => {
+              // correctly formed activity sent
+              const sentActivity = JSON.parse(body)
+              if (sentActivity.type === 'Like') return
+              expect(sentActivity.id).toContain('https://localhost')
+              delete sentActivity.id
+              delete sentActivity.likes
+              delete sentActivity.shares
+              expect(new Date(sentActivity.published).toString()).not.toBe('Invalid Date')
+              delete sentActivity.published
+              expect(sentActivity).toEqual({
+                '@context': apex.context,
+                type: 'Update',
+                actor: testUser.id,
+                to: testUser.followers[0],
+                object: {
+                  id: testUser.liked[0],
+                  type: 'OrderedCollection',
+                  totalItems: 1,
+                  first: 'https://localhost/liked/test?page=true'
+                }
+              })
+              resolve()
             })
-            done()
-          })
+        })
         likeable.actor = [mockedUser]
         like.to = mockedUser
         spyOn(apex, 'address').and.callFake(async () => ['https://mocked.com/inbox/mocked'])
         await apex.store.saveActivity(likeable)
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(like)
           .expect(201)
-          .end(err => { if (err) done(err) })
+        await requestValidated
       })
     })
     describe('add', function () {
@@ -967,69 +1001,73 @@ describe('outbox', function () {
         add.object = addable
         add.target = collection
       })
-      it('fires add event', async function (done) {
+      it('fires add event', async function () {
         await apex.store.saveActivity(addable)
-        app.once('apex-outbox', function (msg) {
-          expect(msg.actor).toEqual(testUser)
-          delete msg.activity.id
-          delete msg.activity.likes
-          delete msg.activity.shares
-          delete msg.activity.published
-          expect(msg.activity).toEqual({
-            _meta: { collection: ['https://localhost/outbox/test'] },
-            type: 'Add',
-            actor: ['https://localhost/u/test'],
-            object: [addable],
-            target: [collection],
-            to: ['https://ignore.com/u/ignored'],
-            audience: ['as:Public']
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-outbox', function (msg) {
+            expect(msg.actor).toEqual(testUser)
+            delete msg.activity.id
+            delete msg.activity.likes
+            delete msg.activity.shares
+            delete msg.activity.published
+            expect(msg.activity).toEqual({
+              _meta: { collection: ['https://localhost/outbox/test'] },
+              type: 'Add',
+              actor: ['https://localhost/u/test'],
+              object: [addable],
+              target: [collection],
+              to: ['https://ignore.com/u/ignored'],
+              audience: ['as:Public']
+            })
+            addable._meta = { collection: [collection] }
+            expect(msg.object).toEqual(addable)
+            resolve()
           })
-          addable._meta = { collection: [collection] }
-          expect(msg.object).toEqual(addable)
-          done()
         })
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(add)
           .expect(201)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
-      it('rejects missing target', async function (done) {
+      it('rejects missing target', async function () {
         delete add.target
         await apex.store.saveActivity(addable)
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(add)
-          .expect(400, done)
+          .expect(400)
       })
-      it('rejects un-owned target', async function (done) {
+      it('rejects un-owned target', async function () {
         add.target = 'https://localhost/u/bob/c/bobs-stuff'
         await apex.store.saveActivity(addable)
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(add)
-          .expect(403, done)
+          .expect(403)
       })
-      it('adds to collection', async function (done) {
+      it('adds to collection', async function () {
         await apex.store.saveActivity(addable)
-        app.once('apex-outbox', async function (msg) {
-          const added = await apex.getAdded(testUser, 'testcol', Infinity, true)
-          delete added.orderedItems[0]._id
-          const standard = apex.mergeJSONLD(addable, { actor: [testUser] })
-          delete standard.actor[0]._meta
-          delete standard.actor[0]._local
-          expect(added.orderedItems[0]).toEqual(standard)
-          done()
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-outbox', async function (msg) {
+            const added = await apex.getAdded(testUser, 'testcol', Infinity, true)
+            delete added.orderedItems[0]._id
+            const standard = apex.mergeJSONLD(addable, { actor: [testUser] })
+            delete standard.actor[0]._meta
+            delete standard.actor[0]._local
+            expect(added.orderedItems[0]).toEqual(standard)
+            resolve()
+          })
         })
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(add)
           .expect(201)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
     })
     describe('remove', function () {
@@ -1047,65 +1085,69 @@ describe('outbox', function () {
         remove.object = added.id
         remove.target = collection
       })
-      it('fires remove event', async function (done) {
+      it('fires remove event', async function () {
         await apex.store.saveActivity(added)
-        app.once('apex-outbox', function (msg) {
-          expect(msg.actor).toEqual(testUser)
-          expect(global.stripIds(msg.activity)).toEqual({
-            _meta: { collection: ['https://localhost/outbox/test'] },
-            type: 'Remove',
-            actor: ['https://localhost/u/test'],
-            object: [added.id],
-            target: [collection],
-            to: ['https://ignore.com/u/ignored'],
-            audience: ['as:Public'],
-            likes: [{ totalItems: [0], type: 'OrderedCollection' }],
-            shares: [{ totalItems: [0], type: 'OrderedCollection' }]
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-outbox', function (msg) {
+            expect(msg.actor).toEqual(testUser)
+            expect(global.stripIds(msg.activity)).toEqual({
+              _meta: { collection: ['https://localhost/outbox/test'] },
+              type: 'Remove',
+              actor: ['https://localhost/u/test'],
+              object: [added.id],
+              target: [collection],
+              to: ['https://ignore.com/u/ignored'],
+              audience: ['as:Public'],
+              likes: [{ totalItems: [0], type: 'OrderedCollection' }],
+              shares: [{ totalItems: [0], type: 'OrderedCollection' }]
+            })
+            added._meta.collection = []
+            expect(msg.object).toEqual(added)
+            resolve()
           })
-          added._meta.collection = []
-          expect(msg.object).toEqual(added)
-          done()
         })
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(remove)
           .expect(201)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
-      it('rejects missing target', async function (done) {
+      it('rejects missing target', async function () {
         delete remove.target
         await apex.store.saveActivity(added)
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(remove)
-          .expect(400, done)
+          .expect(400)
       })
-      it('rejects un-owned target', async function (done) {
+      it('rejects un-owned target', async function () {
         remove.target = 'https://localhost/u/bob/c/bobs-stuff'
         await apex.store.saveActivity(added)
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(remove)
-          .expect(403, done)
+          .expect(403)
       })
-      it('removes from collection', async function (done) {
+      it('removes from collection', async function () {
         await apex.store.saveActivity(added)
         const addedCol = await apex.getAdded(testUser, 'test')
         expect(addedCol.totalItems).toEqual([1])
-        app.once('apex-outbox', async function (msg) {
-          const addedCol = await apex.getAdded(testUser, 'test', Infinity, true)
-          expect(addedCol.orderedItems).toEqual([])
-          done()
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-outbox', async function (msg) {
+            const addedCol = await apex.getAdded(testUser, 'test', Infinity, true)
+            expect(addedCol.orderedItems).toEqual([])
+            resolve()
+          })
         })
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(remove)
           .expect(201)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
     })
     describe('block', function () {
@@ -1117,46 +1159,50 @@ describe('outbox', function () {
         delete block.audience
         block.object = { id: 'https://ignore.com/bob', type: 'Actor' }
       })
-      it('fires block event', async function (done) {
-        app.once('apex-outbox', function (msg) {
-          expect(msg.actor).toEqual(testUser)
-          delete msg.activity.id
-          delete msg.activity.likes
-          delete msg.activity.shares
-          delete msg.activity.published
-          expect(msg.activity).toEqual({
-            _meta: {
-              collection: [
-                testUser.outbox[0],
-                apex.utils.nameToBlockedIRI(testUser.preferredUsername)
-              ]
-            },
-            type: 'Block',
-            actor: [testUser.id],
-            object: [block.object]
+      it('fires block event', async function () {
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-outbox', function (msg) {
+            expect(msg.actor).toEqual(testUser)
+            delete msg.activity.id
+            delete msg.activity.likes
+            delete msg.activity.shares
+            delete msg.activity.published
+            expect(msg.activity).toEqual({
+              _meta: {
+                collection: [
+                  testUser.outbox[0],
+                  apex.utils.nameToBlockedIRI(testUser.preferredUsername)
+                ]
+              },
+              type: 'Block',
+              actor: [testUser.id],
+              object: [block.object]
+            })
+            expect(msg.object).toEqual(block.object)
+            resolve()
           })
-          expect(msg.object).toEqual(block.object)
-          done()
         })
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(block)
           .expect(201)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
-      it('adds to blocklist', async function (done) {
-        app.once('apex-outbox', async function (msg) {
-          const blockList = await apex.getBlocked(testUser, Infinity, true)
-          expect(blockList.orderedItems).toEqual([block.object.id])
-          done()
+      it('adds to blocklist', async function () {
+        const callbackReceived = new Promise(resolve => {
+          app.once('apex-outbox', async function (msg) {
+            const blockList = await apex.getBlocked(testUser, Infinity, true)
+            expect(blockList.orderedItems).toEqual([block.object.id])
+            resolve()
+          })
         })
-        request(app)
+        await request(app)
           .post('/authorized/outbox/test')
           .set('Content-Type', 'application/activity+json')
           .send(block)
           .expect(201)
-          .end(err => { if (err) done(err) })
+        await callbackReceived
       })
     })
     it('fires other activity event', function (done) {
@@ -1191,7 +1237,7 @@ describe('outbox', function () {
         .set('Content-Type', 'application/activity+json')
         .send(arriveAct)
         .expect(201)
-        .end(err => { if (err) done(err) })
+        .end(err => { if (err) done.fail(err) })
     })
   })
   describe('get', function () {
@@ -1225,8 +1271,9 @@ describe('outbox', function () {
         .set('Accept', 'application/activity+json')
         .expect(200)
         .end((err, res) => {
+          if (err) done.fail(err)
           expect(res.body).toEqual(outboxCollection)
-          done(err)
+          done()
         })
     })
     it('returns outbox page as ordered collection page', (done) => {
@@ -1257,8 +1304,9 @@ describe('outbox', function () {
         .set('Accept', 'application/activity+json')
         .expect(200)
         .end((err, res) => {
+          if (err) done.fail(err)
           expect(res.body).toEqual(outboxPage)
-          done(err)
+          done()
         })
     })
     it('includes non-public items when authorized', (done) => {
@@ -1267,6 +1315,7 @@ describe('outbox', function () {
         .set('Accept', 'application/activity+json')
         .expect(200)
         .end((err, res) => {
+          if (err) done.fail(err)
           expect(res.body.orderedItems.length).toBe(4)
           expect(res.body.orderedItems[0]).toEqual({
             type: 'Create',
@@ -1281,7 +1330,7 @@ describe('outbox', function () {
               content: 'Say, did you finish reading that book I lent you?'
             }
           })
-          done(err)
+          done()
         })
     })
     it('starts page after previous item', (done) => {
@@ -1312,8 +1361,9 @@ describe('outbox', function () {
         .set('Accept', 'application/activity+json')
         .expect(200)
         .end((err, res) => {
+          if (err) done.fail(err)
           expect(res.body).toEqual(outboxPage)
-          done(err)
+          done()
         })
     })
   })

--- a/spec/functional/outbox.spec.js
+++ b/spec/functional/outbox.spec.js
@@ -473,7 +473,7 @@ describe('outbox', function () {
         expect(activities[0].object[0]).toEqual(expectedObj)
         expect(activities[1].object[0]).toEqual(expectedObj)
       })
-      // it('adds updated object recipients to audience')
+      it('adds updated object recipients to audience')
       it('federates whole updated object', async function () {
         update.to = ['https://mocked.com/user/mocked']
         update.object[0].to = ['https://mocked.com/user/mocked']

--- a/spec/functional/webfinger.spec.js
+++ b/spec/functional/webfinger.spec.js
@@ -30,7 +30,7 @@ describe('webfinger', function () {
             type: 'application/activity+json',
             href: 'https://localhost/u/test'
           }]
-        }, done)
+        }, err => global.failOrDone(err, done))
     })
   })
 })

--- a/spec/helpers/test-utils.js
+++ b/spec/helpers/test-utils.js
@@ -91,3 +91,17 @@ global.toExternalJSONLD = async function (apex, value, noContext) {
   }
   return value
 }
+
+global.failOrDone = function (err, done) {
+  if (err) {
+    done.fail(err)
+  } else {
+    done()
+  }
+}
+
+global.failIfError = function (err, done) {
+  if (err) {
+    done.fail(err)
+  }
+}

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -7,5 +7,6 @@
     "helpers/**/*.js"
   ],
   "stopSpecOnExpectationFailure": false,
-  "random": false
+  "random": false,
+  "verboseDeprecations": false
 }

--- a/spec/unit/utils.spec.js
+++ b/spec/unit/utils.spec.js
@@ -27,7 +27,7 @@ describe('utils', function () {
   })
   describe('removeMeta', function () {
     it('returns when object does not have the metadata', function () {
-      const obj = { _meta: { collection: [] } }
+      const obj = { }
       expect(apex.removeMeta(obj, 'collection', testUser.inbox[0])).toBe(undefined)
     })
     it('removes the medata', function () {


### PR DESCRIPTION
Fixed deprecation warnings (future failures) related to using async and "done" callbacks together in Jasmine. For async tests, I removed the Jasmine "done" callback and used promises for callback completion signaling. Removed deprecated argument from done callbacks for non-async tests.