### PR TITLE
fix regression in mime type handling close #82

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Fixed
+
+* Fix jsonld validator no longer accepting `application/ld+json; profile="https://www.w3.org/ns/activitystreams"`
+
 ## v4.2.0 (2023-01-18)
 
 ### Added

--- a/pub/consts.js
+++ b/pub/consts.js
@@ -5,7 +5,7 @@ module.exports = {
   ],
   formUrlType: 'application/x-www-form-urlencoded',
   jsonldTypes: [
-    'application/ld+json',
+    'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
     'application/activity+json'
   ],
   // type-is is not able to match this pattern

--- a/spec/functional/object.spec.js
+++ b/spec/functional/object.spec.js
@@ -135,6 +135,61 @@ describe('resources', function () {
       expect(res.get('content-type')?.includes('application/ld+json')).toBeTrue()
       expect(res.body).toEqual(standard)
     })
+    it('handles fully qualified activitypub mime', async function () {
+      const oid = apex.utils.objectIdToIRI()
+      let obj = {
+        id: oid,
+        type: 'Note',
+        content: 'Hello.',
+        attributedTo: 'https://localhost/u/test',
+        to: ['https://ignore.com/u/ignored', apex.consts.publicAddress]
+      }
+      obj = await apex.fromJSONLD(obj)
+      await apex.store.saveObject(obj)
+      const res = await request(app)
+        .get(oid.replace('https://localhost', ''))
+        .set('Accept', 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"')
+        .expect(200)
+      const standard = {
+        '@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'],
+        id: oid,
+        type: 'Note',
+        content: 'Hello.',
+        attributedTo: 'https://localhost/u/test',
+        to: ['https://ignore.com/u/ignored', apex.consts.publicAddress]
+      }
+      // don't match the whole string because express injects other params like charset
+      expect(res.get('content-type').includes('application/ld+json')).toBeTrue()
+      expect(res.get('content-type').includes('profile="https://www.w3.org/ns/activitystreams"')).toBeTrue()
+      expect(res.body).toEqual(standard)
+    })
+    it('handles fully shorthand activitypub mime', async function () {
+      const oid = apex.utils.objectIdToIRI()
+      let obj = {
+        id: oid,
+        type: 'Note',
+        content: 'Hello.',
+        attributedTo: 'https://localhost/u/test',
+        to: ['https://ignore.com/u/ignored', apex.consts.publicAddress]
+      }
+      obj = await apex.fromJSONLD(obj)
+      await apex.store.saveObject(obj)
+      const res = await request(app)
+        .get(oid.replace('https://localhost', ''))
+        .set('Accept', 'application/activity+json')
+        .expect(200)
+      const standard = {
+        '@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'],
+        id: oid,
+        type: 'Note',
+        content: 'Hello.',
+        attributedTo: 'https://localhost/u/test',
+        to: ['https://ignore.com/u/ignored', apex.consts.publicAddress]
+      }
+      // don't match the whole string because express injects other params like charset
+      expect(res.get('content-type').includes('application/activity+json')).toBeTrue()
+      expect(res.body).toEqual(standard)
+    })
   })
   describe('get activity', function () {
     it('returns public activity', async function () {


### PR DESCRIPTION
dependency change within express changed content negotiation matching so an old workaround was breaking the match for `application/ld+json; profile="https://www.w3.org/ns/activitystreams"` and is no longer necessary

Close #82 