### PR TITLE
Signature verification improvements

### DIFF
--- a/pub/activity.js
+++ b/pub/activity.js
@@ -221,6 +221,9 @@ async function resolveActivity (id, includeMeta) {
   if (this.validateActivity(id)) {
     // already activity
     activity = id
+  } else if (!this.isString(id)) {
+    // do not try to fetch if this is an embedded object or otherwise invalid
+    return
   } else {
     activity = await this.store.getActivity(id, includeMeta)
     if (activity) {

--- a/pub/object.js
+++ b/pub/object.js
@@ -5,7 +5,7 @@ module.exports = {
 }
 
 // find object in local DB or fetch from origin server
-async function resolveObject (id, includeMeta, refresh) {
+async function resolveObject (id, includeMeta, refresh, localOnly) {
   let object
   let cached
   if (Array.isArray(id)) {
@@ -20,6 +20,9 @@ async function resolveObject (id, includeMeta, refresh) {
     cached = await this.store.getObject(`${iri.protocol}//${iri.host}${iri.pathname}${iri.search}`, true)
     if (cached && !refresh) {
       return cached
+    }
+    if (localOnly) {
+      return
     }
     // resolve remote object from id
     object = await this.requestObject(id)

--- a/pub/object.js
+++ b/pub/object.js
@@ -15,7 +15,9 @@ async function resolveObject (id, includeMeta, refresh) {
     // already an object
     object = id
   } else {
-    cached = await this.store.getObject(id, true)
+    const iri = new URL(id)
+    // remove any hash from url
+    cached = await this.store.getObject(`${iri.protocol}//${iri.host}${iri.pathname}${iri.search}`, true)
     if (cached && !refresh) {
       return cached
     }

--- a/spec/functional/inbox.spec.js
+++ b/spec/functional/inbox.spec.js
@@ -1272,23 +1272,25 @@ describe('inbox', function () {
           .expect(401)
       })
       it('rejects invalid signature', function () {
+        const act = merge({}, activity)
+        act.actor = 'https://mocked.com/u/mocked'
+        nock('https://mocked.com')
+          .get('/u/mocked')
+          .reply(200, { id: 'https://mocked.com/u/mocked', publicKey: testUser.publicKey })
         return request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')
           .set('Date', new Date().toUTCString())
-          .set('Signature', 'keyId="https://localhost/u/test",algorithm="rsa-sha256",headers="(request-target) host date",signature="asfdlajsflkjasklgja="')
-          .send(activity)
+          .set('Signature', 'keyId="https://mocked.com/u/mocked",algorithm="rsa-sha256",headers="(request-target) host date",signature="asfdlajsflkjasklgja="')
+          .send(act)
           .expect(403)
       })
-      it('handles unverifiable delete', function () {
+      it('handles unverifiable delete without fetching', function () {
         const act = merge({}, activity)
         act.id = 'https://mocked.com/s/abc123'
         act.actor = 'https://mocked.com/u/mocked'
         act.object = act.actor
         act.type = 'Delete'
-        nock('https://mocked.com')
-          .get('/u/mocked')
-          .reply(404)
         return request(app)
           .post('/inbox/test')
           .set('Content-Type', 'application/activity+json')

--- a/spec/unit/activity.spec.js
+++ b/spec/unit/activity.spec.js
@@ -60,4 +60,9 @@ describe('activity utils', function () {
       ])
     })
   })
+  describe('resolveActivity', function () {
+    it('returns undefined if the given a non-activity object', async function () {
+      expect(await apex.resolveActivity({ id: 'https://test.com/o/123', name: 'test' })).toBeUndefined()
+    })
+  })
 })

--- a/spec/unit/object.spec.js
+++ b/spec/unit/object.spec.js
@@ -1,0 +1,26 @@
+/* global describe, beforeAll, beforeEach, it, expect */
+describe('object utils', function () {
+  let testUser
+  let app
+  let apex
+  let client
+  beforeAll(async function () {
+    const init = await global.initApex()
+    testUser = init.testUser
+    app = init.app
+    apex = init.apex
+    client = init.client
+    app.route('/outbox/:actor')
+      .get(apex.net.outbox.get)
+      .post(apex.net.outbox.post)
+  })
+  beforeEach(function () {
+    return global.resetDb(apex, client, testUser)
+  })
+  describe('resolveObject', function () {
+    it('finds cached object even if provided IRI has a hash', async function () {
+      const cached = await apex.resolveObject(`${testUser.id}#main-key`)
+      expect(cached?.id).toBe(testUser.id)
+    })
+  })
+})


### PR DESCRIPTION
* Fix bug not finding already cached actors keys in some cases
* Refetch cached key when verification fails in order to support blind key rotatoin
* Handle unverifiable deletes without fetching
* Avoid error when receiving an embedded object for the object property when an activity object is expected


close #99 
close #97 
close #93 

