### PR TITLE
Call next() instead of sending status 404 if no response in available

### DIFF
--- a/net/responders.js
+++ b/net/responders.js
@@ -7,7 +7,7 @@ module.exports = {
 }
 
 // sends other output as jsonld
-async function result (req, res) {
+async function result (req, res, next) {
   const apex = req.app.locals.apex
   const locals = res.locals.apex
   const result = locals.result
@@ -16,7 +16,7 @@ async function result (req, res) {
       .send(locals.statusMessage || null)
   }
   if (!locals.responseType || !result) {
-    return res.sendStatus(404)
+    return next()
   }
   const body = apex.stringifyPublicJSONLD(await apex.toJSONLD(result))
   res.type(res.locals.apex.responseType)
@@ -33,7 +33,7 @@ function status (req, res) {
 }
 
 // sends the target object as jsonld
-async function target (req, res) {
+async function target (req, res, next) {
   const apex = req.app.locals.apex
   const locals = res.locals.apex
   const target = locals.target
@@ -42,7 +42,7 @@ async function target (req, res) {
       .send(locals.statusMessage || null)
   }
   if (!locals.responseType || !target) {
-    return res.sendStatus(404)
+    return next()
   }
   const body = apex.stringifyPublicJSONLD(await apex.toJSONLD(target))
   res.type(locals.responseType)


### PR DESCRIPTION
It will be useful to call `next()` instead of immediately sending status 404 to client. By calling the next function, it becomes possible to describe the processing to be performed as a fallback when apex cannot respond to the request (for example, when the client cannot accept JSON-LD response).

```js
app.get(routes.actor, apex.net.actor.get, (req, res) => {
	// fallback 
});
```

If no next handler is defined, express.js will automatically send 404 status to client. As such, this fix probably won't require major changes from users of the library.