### PR TITLE
Cache user count for nodeinfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## Unreleased
+
+### Changed
+* Nodeinfo will only count users from database up to once per day, using a cached count for subsequent requests within 24 hours.
+This can help limit query targeting warnings from mongo
+
+### Ops
 * Add [nock fetch work around](https://github.com/nock/nock/issues/2397) to fix tests in node 18.
 * Adjust workflow to run tests using node 18 and 16. Don't run tests against 14.
 

--- a/pub/nodeinfo.js
+++ b/pub/nodeinfo.js
@@ -1,4 +1,18 @@
 'use strict'
+
+const USER_COUNT_FREQ = 24 * 60 * 60 * 1000
+let lastUserCountTime = 0
+let lastUserCount = Promise.resolve(0)
+
+function getUserCountWithCache (store) {
+  const now = Date.now()
+  if (lastUserCountTime + USER_COUNT_FREQ < now) {
+    lastUserCountTime = now
+    lastUserCount = store.getUserCount()
+  }
+  return lastUserCount
+}
+
 module.exports = {
   async generateNodeInfo (version) {
     return {
@@ -10,7 +24,7 @@ module.exports = {
       protocols: ['activitypub'],
       services: { inbound: [], outbound: [] },
       openRegistrations: !!this.settings.openRegistrations,
-      usage: { users: { total: await this.store.getUserCount() } },
+      usage: { users: { total: await getUserCountWithCache(this.store) } },
       metadata: this.settings.nodeInfoMetadata || {}
     }
   }


### PR DESCRIPTION
Despite being covered by index, the count operation still examines every document, resulting in slow performance and monitoring alerts in mongo. This will limit the DB count to 1/day